### PR TITLE
Fix: access Gmail [Gmail]/* special folders (All Mail, Sent Mail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Gmail special folders — `All Mail`, `Sent Mail`, and the other `[Gmail]/*` mailboxes (Drafts, Spam, Trash, Important, Starred) — are now reachable by `list_messages`, `get_message`, `move_message`/`move_messages`, `get_mailbox_info`, and the attachment tools. These live under Mail.app's `[Gmail]` container and could not be resolved by their leaf name (`mailbox "All Mail" of account` fails with `-1728`); only top-level labels worked. A new shared `resolveMailbox` handler resolves a mailbox by either its leaf name or full path, and `list_mailboxes` now returns the full, addressable path (e.g. `[Gmail]/All Mail`) so names round-trip into every other tool.
+
 ## [1.1.0] - 2026-03-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsc && chmod 755 build/index.js && npm run copy-scripts",
-    "copy-scripts": "cp src/bridge/escape-for-json.applescript build/bridge/ && cd src && find domains -name '*.applescript' -exec sh -c 'mkdir -p \"../build/$(dirname \"$1\")\" && cp \"$1\" \"../build/$1\"' _ {} \\;",
+    "copy-scripts": "cp src/bridge/*.applescript build/bridge/ && cd src && find domains -name '*.applescript' -exec sh -c 'mkdir -p \"../build/$(dirname \"$1\")\" && cp \"$1\" \"../build/$1\"' _ {} \\;",
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "tsc --watch",

--- a/src/bridge/applescript-runner.ts
+++ b/src/bridge/applescript-runner.ts
@@ -65,6 +65,30 @@ export function parseAppleScriptOutput(output: string): unknown {
 }
 
 /**
+ * Shared AppleScript handler files in this bridge directory, prepended (in order)
+ * to every domain script so scripts can call `my <handler>(...)`.
+ * - escape-for-json: JSON-string escaping (`my escapeForJson`)
+ * - resolve-mailbox: addressable mailbox lookup (`my resolveMailbox` / `my mailboxFullName`),
+ *   which handles Gmail's `[Gmail]/*` namespaced folders that a plain
+ *   `mailbox "<leaf>" of account` lookup cannot resolve.
+ */
+export const SHARED_HANDLER_FILES = [
+  "escape-for-json.applescript",
+  "resolve-mailbox.applescript",
+];
+
+/**
+ * Compose the final script: shared handler sources first (in order), then the
+ * interpolated domain template, each separated by a newline.
+ */
+export function composeScript(
+  sharedHandlerSources: string[],
+  interpolatedTemplate: string
+): string {
+  return [...sharedHandlerSources, interpolatedTemplate].join("\n");
+}
+
+/**
  * Run an AppleScript file (relative to the domains directory) with optional parameter substitution.
  *
  * Script path is resolved from build/bridge/ → build/domains/<scriptPath>.
@@ -82,16 +106,17 @@ export async function runAppleScript(
   const thisDir = dirname(fileURLToPath(import.meta.url));
   const resolvedScriptPath = join(thisDir, "..", "domains", scriptPath);
 
-  // Read shared escapeForJson handler and domain script template
-  const sharedHandlerPath = join(thisDir, "escape-for-json.applescript");
-  const [sharedHandler, template] = await Promise.all([
-    readFile(sharedHandlerPath, "utf8"),
+  // Read all shared handlers (escapeForJson, resolveMailbox, …) and the domain template
+  const [sharedHandlers, template] = await Promise.all([
+    Promise.all(
+      SHARED_HANDLER_FILES.map((file) => readFile(join(thisDir, file), "utf8"))
+    ),
     readFile(resolvedScriptPath, "utf8"),
   ]);
 
-  // Substitute params if provided, then prepend shared handler
+  // Substitute params if provided, then prepend the shared handlers
   const interpolated = params ? substituteParams(template, params) : template;
-  const script = sharedHandler + "\n" + interpolated;
+  const script = composeScript(sharedHandlers, interpolated);
 
   // Write to temp file
   const tempDir = await mkdtemp(join(tmpdir(), "macos-mail-mcp-"));

--- a/src/bridge/resolve-mailbox.applescript
+++ b/src/bridge/resolve-mailbox.applescript
@@ -1,0 +1,55 @@
+-- macos-mail-mcp — shared mailbox-resolution handlers.
+-- Prepended to every domain script by the runner (see applescript-runner.ts),
+-- so any script can call `my resolveMailbox(...)` / `my mailboxFullName(...)`.
+
+-- Build the full, addressable path of a mailbox by walking its container chain.
+-- Gmail's special folders live under a "[Gmail]" parent, so the mailbox whose
+-- leaf name is "All Mail" is only addressable as "[Gmail]/All Mail". We prepend
+-- each parent name until the parent is the account itself: in Mail's model a
+-- folder grouping has class "container" (e.g. "[Gmail]", "Sync Issues") and a
+-- nested user folder has class "mailbox", while the account is an "... account"
+-- class — so we stop as soon as the parent's class contains "account". A
+-- top-level mailbox stops on the first step and returns just its leaf name.
+on mailboxFullName(mb)
+    using terms from application "Mail"
+        set theName to (name of mb as text)
+        set cur to mb
+        repeat
+            try
+                set c to container of cur
+            on error
+                exit repeat
+            end try
+            if (class of c as text) contains "account" then exit repeat
+            set theName to ((name of c as text) & "/" & theName)
+            set cur to c
+        end repeat
+        return theName
+    end using terms from
+end mailboxFullName
+
+-- Resolve a mailbox by name within an account, returning an addressable reference.
+-- Accepts either the full path ("[Gmail]/All Mail") or the leaf name ("All Mail").
+-- A direct lookup handles top-level mailboxes and full paths; the fallback scan
+-- handles leaf names of namespaced mailboxes (Gmail's [Gmail]/* folders), which
+-- Mail.app lists but cannot resolve via `mailbox "<leaf>" of account`.
+on resolveMailbox(acctName, mboxName)
+    tell application "Mail"
+        set acct to account acctName
+        -- 1. Direct address. `get name` forces evaluation so a bad leaf errors here.
+        try
+            set mb to mailbox mboxName of acct
+            get name of mb
+            return mb
+        end try
+        -- 2. Fallback: match on leaf OR full path, return the full-path reference.
+        repeat with candidate in (every mailbox of acct)
+            set leafName to (name of candidate as text)
+            set fullName to my mailboxFullName(candidate)
+            if (mboxName is leafName) or (mboxName is fullName) then
+                return mailbox fullName of acct
+            end if
+        end repeat
+        error "Can't find mailbox \"" & mboxName & "\" in account \"" & acctName & "\"" number -1728
+    end tell
+end resolveMailbox

--- a/src/bridge/resolve-mailbox.applescript
+++ b/src/bridge/resolve-mailbox.applescript
@@ -42,14 +42,23 @@ on resolveMailbox(acctName, mboxName)
             get name of mb
             return mb
         end try
-        -- 2. Fallback: match on leaf OR full path, return the full-path reference.
+        -- 2. Fallback: collect mailboxes matching by leaf OR full path, then return
+        -- the full-path reference. A full-path input matches at most one mailbox; a
+        -- bare leaf name may match several under different containers, in which case
+        -- we fail loudly rather than silently operate on the wrong mailbox.
+        set matchPaths to {}
         repeat with candidate in (every mailbox of acct)
             set leafName to (name of candidate as text)
             set fullName to my mailboxFullName(candidate)
             if (mboxName is leafName) or (mboxName is fullName) then
-                return mailbox fullName of acct
+                set end of matchPaths to fullName
             end if
         end repeat
+        if (count of matchPaths) is 1 then
+            return mailbox (item 1 of matchPaths) of acct
+        else if (count of matchPaths) > 1 then
+            error "Mailbox name \"" & mboxName & "\" is ambiguous in account \"" & acctName & "\" -- use the full path (see list_mailboxes)" number -1728
+        end if
         error "Can't find mailbox \"" & mboxName & "\" in account \"" & acctName & "\"" number -1728
     end tell
 end resolveMailbox

--- a/src/domains/compose/scripts/forward-message.applescript
+++ b/src/domains/compose/scripts/forward-message.applescript
@@ -5,7 +5,7 @@ end if
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
         set fwdMsg to forward msg without opening window
         tell fwdMsg

--- a/src/domains/compose/scripts/reply-to-message.applescript
+++ b/src/domains/compose/scripts/reply-to-message.applescript
@@ -5,7 +5,7 @@ end if
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
         if "{{replyAll}}" is "true" then
             set replyMsg to reply msg reply to all yes without opening window

--- a/src/domains/mailboxes/scripts/create-mailbox.applescript
+++ b/src/domains/mailboxes/scripts/create-mailbox.applescript
@@ -6,7 +6,7 @@ tell application "Mail"
         if theParent is "__NONE__" then
             set newMbox to make new mailbox with properties {name:"{{mailboxName}}"} at theAccount
         else
-            set parentMbox to mailbox theParent of theAccount
+            set parentMbox to my resolveMailbox("{{accountName}}", theParent)
             set newMbox to make new mailbox with properties {name:"{{mailboxName}}"} at parentMbox
         end if
 

--- a/src/domains/mailboxes/scripts/get-mailbox-info.applescript
+++ b/src/domains/mailboxes/scripts/get-mailbox-info.applescript
@@ -1,7 +1,7 @@
 tell application "Mail"
     try
         set acct to account "{{accountName}}"
-        set mbox to mailbox "{{mailboxName}}" of acct
+        set mbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set mboxName to my escapeForJson(name of mbox)
         set acctName to my escapeForJson(name of acct)
         set mboxUnread to unread count of mbox

--- a/src/domains/mailboxes/scripts/list-mailboxes.applescript
+++ b/src/domains/mailboxes/scripts/list-mailboxes.applescript
@@ -7,7 +7,7 @@ tell application "Mail"
                 set acctName to my escapeForJson(name of acct)
                 set allMailboxes to every mailbox of acct
                 repeat with mbox in allMailboxes
-                    set mboxName to my escapeForJson(name of mbox)
+                    set mboxName to my escapeForJson(my mailboxFullName(mbox))
                     set mboxUnread to unread count of mbox
                     if mailboxList is not "" then set mailboxList to mailboxList & ", "
                     set mailboxList to mailboxList & "{\"name\": \"" & mboxName & "\", \"unreadCount\": " & mboxUnread & ", \"accountName\": \"" & acctName & "\"}"
@@ -18,7 +18,7 @@ tell application "Mail"
             set acctName to my escapeForJson(name of acct)
             set allMailboxes to every mailbox of acct
             repeat with mbox in allMailboxes
-                set mboxName to my escapeForJson(name of mbox)
+                set mboxName to my escapeForJson(my mailboxFullName(mbox))
                 set mboxUnread to unread count of mbox
                 if mailboxList is not "" then set mailboxList to mailboxList & ", "
                 set mailboxList to mailboxList & "{\"name\": \"" & mboxName & "\", \"unreadCount\": " & mboxUnread & ", \"accountName\": \"" & acctName & "\"}"

--- a/src/domains/messages/scripts/delete-message.applescript
+++ b/src/domains/messages/scripts/delete-message.applescript
@@ -1,6 +1,6 @@
 tell application "Mail"
     try
-        set msg to (first message of mailbox "{{mailboxName}}" of account "{{accountName}}" whose id is {{messageId}})
+        set msg to (first message of (my resolveMailbox("{{accountName}}", "{{mailboxName}}")) whose id is {{messageId}})
         delete msg
         return "{\"success\": true}"
     on error errMsg number errNum

--- a/src/domains/messages/scripts/flag-message.applescript
+++ b/src/domains/messages/scripts/flag-message.applescript
@@ -1,6 +1,6 @@
 tell application "Mail"
     try
-        set msg to (first message of mailbox "{{mailboxName}}" of account "{{accountName}}" whose id is {{messageId}})
+        set msg to (first message of (my resolveMailbox("{{accountName}}", "{{mailboxName}}")) whose id is {{messageId}})
         set flagged status of msg to {{flagged}}
         if {{flagIndex}} is not -1 then
             set flag index of msg to {{flagIndex}}

--- a/src/domains/messages/scripts/get-message.applescript
+++ b/src/domains/messages/scripts/get-message.applescript
@@ -47,7 +47,7 @@ end buildRecipientsJson
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
 
         set msgId to id of msg

--- a/src/domains/messages/scripts/list-attachments.applescript
+++ b/src/domains/messages/scripts/list-attachments.applescript
@@ -34,7 +34,7 @@ end mimeFromExtension
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
 
         set attachJson to ""

--- a/src/domains/messages/scripts/list-messages.applescript
+++ b/src/domains/messages/scripts/list-messages.applescript
@@ -1,7 +1,6 @@
 tell application "Mail"
     try
-        set theAccount to account "{{accountName}}"
-        set theMailbox to mailbox "{{mailboxName}}" of theAccount
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set allMessages to messages of theMailbox
         set totalCount to count of allMessages
         set limitNum to {{limit}} as integer

--- a/src/domains/messages/scripts/mark-read.applescript
+++ b/src/domains/messages/scripts/mark-read.applescript
@@ -1,6 +1,6 @@
 tell application "Mail"
     try
-        set msg to (first message of mailbox "{{mailboxName}}" of account "{{accountName}}" whose id is {{messageId}})
+        set msg to (first message of (my resolveMailbox("{{accountName}}", "{{mailboxName}}")) whose id is {{messageId}})
         set read status of msg to {{read}}
         return "{\"success\": true}"
     on error errMsg number errNum

--- a/src/domains/messages/scripts/move-message.applescript
+++ b/src/domains/messages/scripts/move-message.applescript
@@ -1,7 +1,8 @@
 tell application "Mail"
     try
-        set msg to (first message of mailbox "{{mailboxName}}" of account "{{accountName}}" whose id is {{messageId}})
-        set mailbox of msg to mailbox "{{toMailbox}}" of account "{{accountName}}"
+        set srcMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
+        set msg to (first message of srcMailbox whose id is {{messageId}})
+        set mailbox of msg to (my resolveMailbox("{{accountName}}", "{{toMailbox}}"))
         return "{\"success\": true}"
     on error errMsg number errNum
         return "{\"error\": \"" & my escapeForJson(errMsg) & "\", \"errorNumber\": " & errNum & "}"

--- a/src/domains/messages/scripts/move-messages.applescript
+++ b/src/domains/messages/scripts/move-messages.applescript
@@ -1,8 +1,7 @@
 tell application "Mail"
     try
-        set theAccount to account "{{accountName}}"
-        set srcMailbox to mailbox "{{mailboxName}}" of theAccount
-        set destMailbox to mailbox "{{toMailbox}}" of theAccount
+        set srcMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
+        set destMailbox to my resolveMailbox("{{accountName}}", "{{toMailbox}}")
 
         set idString to "{{messageIds}}"
         set AppleScript's text item delimiters to ","

--- a/src/domains/messages/scripts/read-attachment.applescript
+++ b/src/domains/messages/scripts/read-attachment.applescript
@@ -6,7 +6,7 @@ set targetAttName to do shell script "cat " & quoted form of "{{attNameFile}}"
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
 
         set targetAttachment to missing value

--- a/src/domains/messages/scripts/save-all-attachments.applescript
+++ b/src/domains/messages/scripts/save-all-attachments.applescript
@@ -2,7 +2,7 @@ set saveFolderPath to "{{savePath}}"
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
         set savedFilesJson to ""
         set savedCount to 0

--- a/src/domains/messages/scripts/save-attachment.applescript
+++ b/src/domains/messages/scripts/save-attachment.applescript
@@ -4,7 +4,7 @@ set targetAttName to do shell script "cat " & quoted form of "{{attNameFile}}"
 
 tell application "Mail"
     try
-        set theMailbox to mailbox "{{mailboxName}}" of account "{{accountName}}"
+        set theMailbox to my resolveMailbox("{{accountName}}", "{{mailboxName}}")
         set msg to (first message of theMailbox whose id is {{messageId}})
 
         set targetAttachment to missing value

--- a/src/domains/messages/scripts/search-messages.applescript
+++ b/src/domains/messages/scripts/search-messages.applescript
@@ -98,7 +98,7 @@ tell application "Mail"
                     end repeat
                 else
                     try
-                        set mb to mailbox theMailboxName of acct
+                        set mb to my resolveMailbox((name of acct), theMailboxName)
                         set {partial, partialCount, seenIds} to my searchInMailbox(mb, theField, theQuery, limitNum - totalFound, seenIds, afterDate, beforeDate)
                         if partial is not "" then
                             if resultList is not "" then set resultList to resultList & ", "
@@ -121,7 +121,7 @@ tell application "Mail"
                     set totalFound to totalFound + partialCount
                 end repeat
             else
-                set mb to mailbox theMailboxName of theAccount
+                set mb to my resolveMailbox(theAccountName, theMailboxName)
                 set {partial, partialCount, seenIds} to my searchInMailbox(mb, theField, theQuery, limitNum, seenIds, afterDate, beforeDate)
                 if partial is not "" then set resultList to partial
             end if

--- a/tests/bridge/applescript-runner.test.ts
+++ b/tests/bridge/applescript-runner.test.ts
@@ -1,6 +1,6 @@
 // tests/bridge/applescript-runner.test.ts
 import { describe, it, expect } from "vitest";
-import { escapeForAppleScript, substituteParams, parseAppleScriptOutput } from "../../src/bridge/applescript-runner.js";
+import { escapeForAppleScript, substituteParams, parseAppleScriptOutput, composeScript, SHARED_HANDLER_FILES } from "../../src/bridge/applescript-runner.js";
 
 describe("escapeForAppleScript", () => {
   it("escapes double quotes", () => {
@@ -70,5 +70,27 @@ describe("parseAppleScriptOutput", () => {
     expect(() => parseAppleScriptOutput(input)).toThrow(
       'Can\'t get mailbox "INBOX" of account "Gmail"'
     );
+  });
+});
+
+describe("composeScript", () => {
+  it("prepends shared handlers in order, then the template, newline-separated", () => {
+    expect(composeScript(["HANDLER_A", "HANDLER_B"], "TEMPLATE")).toBe(
+      "HANDLER_A\nHANDLER_B\nTEMPLATE"
+    );
+  });
+  it("handles a single handler", () => {
+    expect(composeScript(["ONLY"], "TPL")).toBe("ONLY\nTPL");
+  });
+});
+
+describe("SHARED_HANDLER_FILES", () => {
+  it("includes the escapeForJson and resolveMailbox handlers, in that order", () => {
+    // resolve-mailbox must be present so every script can call `my resolveMailbox(...)`;
+    // order matters because mailboxFullName/resolveMailbox are defined here and used elsewhere.
+    expect(SHARED_HANDLER_FILES).toEqual([
+      "escape-for-json.applescript",
+      "resolve-mailbox.applescript",
+    ]);
   });
 });

--- a/tests/domains/compose/compose.tools.test.ts
+++ b/tests/domains/compose/compose.tools.test.ts
@@ -90,4 +90,22 @@ describe("compose tools", () => {
       expect.objectContaining({ to: "alice@test.com", bodyFile: "__NONE__" })
     );
   });
+
+  it("reply_to_message forwards a [Gmail]/* mailbox path unchanged", async () => {
+    const { handleReplyToMessage } = await import("../../../src/domains/compose/compose.tools.js");
+    await handleReplyToMessage(123, "[Gmail]/All Mail", "Gmail", "Thanks!", false);
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "compose/scripts/reply-to-message.applescript",
+      expect.objectContaining({ messageId: "123", mailboxName: "[Gmail]/All Mail", accountName: "Gmail" })
+    );
+  });
+
+  it("forward_message forwards a [Gmail]/* mailbox path unchanged", async () => {
+    const { handleForwardMessage } = await import("../../../src/domains/compose/compose.tools.js");
+    await handleForwardMessage(123, "[Gmail]/Sent Mail", "Gmail", "alice@test.com");
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "compose/scripts/forward-message.applescript",
+      expect.objectContaining({ mailboxName: "[Gmail]/Sent Mail", accountName: "Gmail", to: "alice@test.com" })
+    );
+  });
 });

--- a/tests/domains/mailboxes/mailboxes.tools.test.ts
+++ b/tests/domains/mailboxes/mailboxes.tools.test.ts
@@ -46,4 +46,14 @@ describe("mailboxes tools", () => {
     await handleGetMailboxInfo("Gmail", "INBOX");
     expect(mockRunAppleScript).toHaveBeenCalledWith("mailboxes/scripts/get-mailbox-info.applescript", { accountName: "Gmail", mailboxName: "INBOX" });
   });
+
+  it("get_mailbox_info forwards a full [Gmail]/* path unchanged", async () => {
+    mockRunAppleScript.mockResolvedValue({ name: "Sent Mail", container: "[Gmail]" });
+    const { handleGetMailboxInfo } = await import("../../../src/domains/mailboxes/mailboxes.tools.js");
+    await handleGetMailboxInfo("Gmail", "[Gmail]/Sent Mail");
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "mailboxes/scripts/get-mailbox-info.applescript",
+      { accountName: "Gmail", mailboxName: "[Gmail]/Sent Mail" }
+    );
+  });
 });

--- a/tests/domains/messages/messages.tools.test.ts
+++ b/tests/domains/messages/messages.tools.test.ts
@@ -231,3 +231,51 @@ describe("messages tools - attachments", () => {
       .rejects.toThrow("Binary file type");
   });
 });
+
+describe("messages tools - Gmail namespaced mailbox paths", () => {
+  // Regression guard for the [Gmail]/* fix: the tools layer must forward the full
+  // addressable path to AppleScript verbatim (sanitize/escaping must not mangle it).
+  beforeEach(() => { vi.resetModules(); vi.clearAllMocks(); });
+
+  it("list_messages forwards a [Gmail]/* path unchanged", async () => {
+    mockRunAppleScript.mockResolvedValue([]);
+    const { handleListMessages } = await import("../../../src/domains/messages/messages.tools.js");
+    await handleListMessages("Gmail", "[Gmail]/All Mail", 25, 0);
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "messages/scripts/list-messages.applescript",
+      expect.objectContaining({ accountName: "Gmail", mailboxName: "[Gmail]/All Mail" }),
+      undefined
+    );
+  });
+
+  it("get_message forwards a [Gmail]/* path unchanged", async () => {
+    mockRunAppleScript.mockResolvedValue({ id: 123 });
+    const { handleGetMessage } = await import("../../../src/domains/messages/messages.tools.js");
+    await handleGetMessage(123, "Gmail", "[Gmail]/All Mail");
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "messages/scripts/get-message.applescript",
+      { messageId: "123", mailboxName: "[Gmail]/All Mail", accountName: "Gmail" }
+    );
+  });
+
+  it("move_message forwards a [Gmail]/* source and label destination unchanged", async () => {
+    mockRunAppleScript.mockResolvedValue({ success: true });
+    const { handleMoveMessage } = await import("../../../src/domains/messages/messages.tools.js");
+    await handleMoveMessage(123, "[Gmail]/All Mail", "Archive", "Gmail");
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "messages/scripts/move-message.applescript",
+      { messageId: "123", mailboxName: "[Gmail]/All Mail", toMailbox: "Archive", accountName: "Gmail" }
+    );
+  });
+
+  it("move_messages forwards a [Gmail]/* source unchanged", async () => {
+    mockRunAppleScript.mockResolvedValue({ moved: 1, failed: 0, errors: [] });
+    const { handleMoveMessages } = await import("../../../src/domains/messages/messages.tools.js");
+    await handleMoveMessages("Gmail", "[Gmail]/Sent Mail", [123], "Archive");
+    expect(mockRunAppleScript).toHaveBeenCalledWith(
+      "messages/scripts/move-messages.applescript",
+      { accountName: "Gmail", mailboxName: "[Gmail]/Sent Mail", toMailbox: "Archive", messageIds: "123" },
+      { timeout: 120_000 }
+    );
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -45,6 +45,17 @@ describe("sanitize", () => {
   it("handles multiple separate newline groups", () => {
     expect(sanitize("a\nb\nc\nd")).toBe("a b c d");
   });
+
+  it("preserves brackets and slashes (Gmail [Gmail]/* mailbox paths)", () => {
+    // The fix for Gmail special folders depends on these characters surviving
+    // sanitize so "[Gmail]/All Mail" reaches AppleScript intact.
+    expect(sanitize("[Gmail]/All Mail")).toBe("[Gmail]/All Mail");
+    expect(sanitize("[Gmail]/Sent Mail")).toBe("[Gmail]/Sent Mail");
+  });
+
+  it("preserves a nested label path unchanged", () => {
+    expect(sanitize("Projects/2024/Q3")).toBe("Projects/2024/Q3");
+  });
 });
 
 describe("expandTilde", () => {


### PR DESCRIPTION
## Problem

Gmail's special folders — **All Mail**, **Sent Mail**, Drafts, Spam, Trash, Important, Starred — live under Mail.app's `[Gmail]` container. Mail lists them by leaf name, but they are only *addressable* by full path; a by-name lookup on the leaf fails:

```
mailbox "All Mail" of account "<acct>"          ->  -1728  "Can't get mailbox"
mailbox "[Gmail]/All Mail" of account "<acct>"   ->  ok
```

Every tool except `search_messages` resolved mailboxes via `mailbox "<name>" of account`, so **reading, moving, and managing messages in these folders all failed** — only top-level labels (INBOX, user labels) worked.

## Fix

- New shared `resolve-mailbox.applescript` handler, prepended to every script by the runner:
  - `resolveMailbox(account, name)` — resolves a mailbox by **leaf name or full path**, returning an addressable reference (direct lookup, then a scan that matches leaf/full and returns the full-path reference).
  - `mailboxFullName(mb)` — walks the container chain, stopping at the account, so `[Gmail]/*` and nested user folders get their true path.
- Every by-name script routes through `resolveMailbox` (get / list / move / move_messages / delete / flag / mark_read / attachments / get_mailbox_info / search / create).
- `list_mailboxes` now returns the **full addressable path**, so names round-trip into the other tools.
- Runner refactored to prepend an ordered list of shared handlers (`SHARED_HANDLER_FILES`) via a pure, unit-tested `composeScript()`.

## Testing

- **72 unit tests** (was 62): `sanitize` preserves `[` / `]` / `/`; runner wiring (`composeScript`, `SHARED_HANDLER_FILES`); tools forward `[Gmail]/*` paths verbatim.
- All **21 composed scripts** pass `osacompile` (syntax + Mail terminology).
- **Validated live against Mail.app:** leaf names (`All Mail`, `Sent Mail`) resolve to their `[Gmail]/*` paths and list messages; full paths resolve directly; INBOX and top-level labels unchanged (no regression).

AppleScript behavior is validated live — the repo's unit tests mock the runner and don't execute AppleScript — while the TS surface is covered by the 72 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
