### PR TITLE
feat(compose): sender account selection via fromAccount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 build/
+coverage/
 *.tsbuildinfo
 .DS_Store
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Sender account selection — `send_message`, `reply_to_message` and `forward_message` accept an
+  optional `fromAccount`, given as either a Mail account name (`"Google"`) or any address that
+  account owns (`"you@gmail.com"`), matched case-insensitively against the enabled accounts.
+  Previously there was no way to choose the sending account: Mail silently used whatever is set
+  under Settings → Composing, so a message meant to go out from a work address could be sent from
+  a personal one with the tool still reporting `{"success": true}`. An unrecognised value is now
+  an error naming the valid accounts rather than a silent fallback to the default.
+- All three compose tools now return the account they actually sent from, e.g.
+  `{"success": true, "sender": "Your Name <you@work.com>"}`. This is reported whether or not
+  `fromAccount` was passed, so Mail's own choice of account is visible in the result instead of
+  only being discoverable afterwards by finding the message in a Sent mailbox.
+- `list_accounts` and `get_account_detail` now report each account's `fullName` — the display name
+  Mail sends as, which is what the `"Name <address>"` sender string is built from.
+
+### Changed
+
+- `accountName` on `reply_to_message` / `forward_message` is documented as locating the source
+  message only. It never controlled which account sends, and the name invited the opposite
+  assumption; `fromAccount` is the sender selector.
+
+### Notes
+
+- Whether an unqualified reply or forward inherits the account that received the original message
+  or falls back to Mail's global default is still unconfirmed, so the default behaviour is
+  deliberately unchanged. The `sender` now returned in the result makes it directly observable.
+
 ## [1.2.0] - 2026-06-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Works with **any email account configured in Mail.app** — iCloud, Gmail, Outlo
 - **MCP SDK:** `@modelcontextprotocol/sdk` v1.x (stdio transport)
 - **Mail integration:** AppleScript via `osascript` (execFile, not exec — prevents shell injection)
 - **Validation:** Zod schemas on all tool inputs
-- **Testing:** Vitest (62 unit tests, mocked bridge — no real Mail.app needed)
+- **Testing:** Vitest (189 unit tests, mocked bridge — no real Mail.app needed)
 
 ## Architecture
 
@@ -39,6 +39,7 @@ src/
     mailboxes/  — 3 tools: list_mailboxes, get_mailbox_info, create_mailbox
     messages/   — 8 message tools + 4 attachment tools (12 total in this domain)
     compose/    — 3 tools: send_message, reply_to_message, forward_message
+                  sender.ts resolves the optional fromAccount to a sender string
 tests/
   utils.test.ts                — Tests for sanitize, expandTilde
   bridge/applescript-runner.test.ts — Tests for escaping, param substitution, JSON parsing
@@ -59,6 +60,22 @@ AppleScript string literals cannot span multiple lines. Any content that may con
 - **Attachment names** — save/read_attachment write to `attname.txt`
 
 Always clean up temp files in a `finally` block.
+
+### Sender Resolution
+
+Compose tools take an optional `fromAccount` (account name or any address it owns).
+`resolveSender()` in `src/domains/compose/sender.ts` reads the account list, matches
+case-insensitively against **enabled** accounts only, and returns the `"Name <address>"`
+string Mail expects in an outgoing message's `sender` property. It throws on no match or
+on an ambiguous match — never falling back to the default account, since a silent fallback
+sending mail from the wrong address is the bug this guards against.
+
+Resolution runs *before* any temp-file setup so a bad value fails without leaving a
+directory behind. Omitting `fromAccount` passes the `__NONE__` sentinel and the script
+leaves `sender` alone, preserving Mail's own choice.
+
+Every compose script reads `sender` back off the message **before** `send` and returns it,
+so the result reports the account used even when the caller specified none.
 
 ### sanitize() Function
 
@@ -115,12 +132,16 @@ ISO 8601 dates are converted to seconds-from-now in TypeScript (`dateToSecondsFr
 - **MIME type** often returns `missing value` from Mail.app. Scripts use `mimeFromExtension()` as fallback.
 - **Attachment names with quotes/backslashes** — handled via temp file matching to avoid escaping mismatches.
 - **`whose` clause performance** — Mail.app loads ALL matching messages into memory before applying limits. Warn users to scope searches by account/mailbox.
+- **`full name` of an account** can be `missing value`; scripts wrap it in `try` and fall back to an empty string, which makes `resolveSender()` emit a bare address instead of `"Name <address>"`. Mail accepts both.
+- **`accountName` on reply/forward is a lookup param**, not a sender selector — it feeds `resolveMailbox()` to find the source message. `fromAccount` controls who sends.
+- **Reply/forward sender inheritance is unverified.** Whether Mail uses the receiving account or the global default when `sender` is unset has not been confirmed, so neither script sets a default. The `sender` returned in the result makes the actual behaviour observable.
 
 ## Build & Test
 
 ```bash
 npm run build        # tsc + copy .applescript files to build/
-npm test             # Run 56 unit tests
+npm test             # Run 189 unit tests
+npm run test:coverage # Run tests with a v8 coverage report
 npm run test:watch   # Watch mode
 npm run dev          # TypeScript watch mode
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ On first use, macOS will prompt to grant automation permission for controlling M
 
 | Tool | Description |
 |---|---|
-| `list_accounts` | List all mail accounts (name, type, enabled, emails) |
+| `list_accounts` | List all mail accounts (name, type, enabled, full name, emails) |
 | `get_account_detail` | Get full account details (server, port, SSL, mailbox count) |
 
 ### Mailboxes (3)
@@ -140,6 +140,38 @@ On first use, macOS will prompt to grant automation permission for controlling M
 | `reply_to_message` | Reply or reply-all to a message |
 | `forward_message` | Forward a message to a new recipient |
 
+All three accept an optional `fromAccount` to choose which account sends, and report
+the account actually used — see [Choosing the sending account](#choosing-the-sending-account).
+
+### Choosing the sending account
+
+By default Mail sends from whichever account is set under **Settings → Composing →
+"Send new messages from"**. Pass `fromAccount` to override it, using either the account
+name or any address that account owns (matching is case-insensitive):
+
+```jsonc
+{ "to": "client@example.com", "subject": "Invoice", "body": "…",
+  "fromAccount": "you@work.com" }
+```
+
+An unrecognised value is an error listing the accounts you can choose from — it never
+silently falls back to the default. Only enabled accounts can be selected.
+
+Every compose tool returns the account it actually sent from, whether or not you passed
+`fromAccount`:
+
+```json
+{ "success": true, "sender": "Your Name <you@work.com>" }
+```
+
+Omitting `fromAccount` is still the way to accept Mail's own choice; the `sender` in the
+result tells you what that choice was, so a wrong sending account is visible immediately
+rather than only discoverable later in the Sent mailbox.
+
+On `reply_to_message` and `forward_message`, note that `accountName` is not a sender
+selector — it identifies where the *source* message lives. Use `fromAccount` to control
+who the reply or forward comes from.
+
 ## Architecture
 
 ```
@@ -162,6 +194,7 @@ src/
       scripts/*.applescript
     compose/
       compose.tools.ts
+      sender.ts                     # Resolves fromAccount to a "Name <address>" sender
       scripts/*.applescript
 tests/
   utils.test.ts                     # Shared utility tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.0.0",
+        "@vitest/coverage-v8": "^4.1.10",
         "typescript": "^6.0.0",
         "vitest": "^4.0.0"
       },
@@ -24,38 +25,64 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -70,12 +97,33 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
@@ -117,29 +165,10 @@
         }
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -147,9 +176,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
       "cpu": [
         "arm64"
       ],
@@ -164,9 +193,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
       "cpu": [
         "arm64"
       ],
@@ -181,9 +210,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
       "cpu": [
         "x64"
       ],
@@ -198,9 +227,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
       "cpu": [
         "x64"
       ],
@@ -215,9 +244,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
       "cpu": [
         "arm"
       ],
@@ -232,9 +261,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
       "cpu": [
         "arm64"
       ],
@@ -252,9 +281,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
       "cpu": [
         "arm64"
       ],
@@ -272,9 +301,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
       "cpu": [
         "ppc64"
       ],
@@ -292,9 +321,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
       "cpu": [
         "s390x"
       ],
@@ -312,9 +341,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +361,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
       "cpu": [
         "x64"
       ],
@@ -352,9 +381,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
       "cpu": [
         "arm64"
       ],
@@ -368,29 +397,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
       "cpu": [
         "arm64"
       ],
@@ -405,9 +415,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
       "cpu": [
         "x64"
       ],
@@ -434,17 +444,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -481,17 +480,48 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -500,13 +530,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -527,9 +557,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -540,13 +570,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -554,14 +584,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -570,9 +600,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -580,13 +610,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -648,6 +678,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -1184,6 +1226,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1216,6 +1268,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1289,6 +1348,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -1297,6 +1395,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1311,9 +1416,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1327,23 +1432,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -1362,9 +1467,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -1383,9 +1488,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -1404,9 +1509,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -1425,9 +1530,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -1446,9 +1551,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -1470,9 +1575,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -1494,9 +1599,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -1518,9 +1623,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -1542,9 +1647,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -1563,9 +1668,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -1591,6 +1696,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1781,9 +1914,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1893,13 +2026,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1909,21 +2042,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
       }
     },
     "node_modules/router": {
@@ -1947,6 +2079,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2132,6 +2277,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2184,14 +2342,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.1.0",
@@ -2264,16 +2414,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2290,7 +2440,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2342,19 +2492,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2382,12 +2532,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build": "tsc && chmod 755 build/index.js && npm run copy-scripts",
     "copy-scripts": "cp src/bridge/*.applescript build/bridge/ && cd src && find domains -name '*.applescript' -exec sh -c 'mkdir -p \"../build/$(dirname \"$1\")\" && cp \"$1\" \"../build/$1\"' _ {} \\;",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "dev": "tsc --watch",
     "prepublishOnly": "npm run build && npm test"
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0"
   }

--- a/src/domains/accounts/scripts/get-account-detail.applescript
+++ b/src/domains/accounts/scripts/get-account-detail.applescript
@@ -39,8 +39,13 @@ tell application "Mail"
             set rawUser to user name of acct
             if rawUser is not missing value then set acctUser to my escapeForJson(rawUser as text)
         end try
+        set acctFullName to ""
+        try
+            set rawFullName to full name of acct
+            if rawFullName is not missing value then set acctFullName to my escapeForJson(rawFullName as text)
+        end try
         set acctMailboxCount to count of mailboxes of acct
-        return "{\"name\": \"" & acctName & "\", \"type\": \"" & acctType & "\", \"enabled\": " & acctEnabled & ", \"emails\": [" & emailsJson & "], \"serverName\": \"" & acctServer & "\", \"port\": " & acctPort & ", \"usesSsl\": " & acctSsl & ", \"userName\": \"" & acctUser & "\", \"mailboxCount\": " & acctMailboxCount & "}"
+        return "{\"name\": \"" & acctName & "\", \"type\": \"" & acctType & "\", \"enabled\": " & acctEnabled & ", \"fullName\": \"" & acctFullName & "\", \"emails\": [" & emailsJson & "], \"serverName\": \"" & acctServer & "\", \"port\": " & acctPort & ", \"usesSsl\": " & acctSsl & ", \"userName\": \"" & acctUser & "\", \"mailboxCount\": " & acctMailboxCount & "}"
     on error errMsg number errNum
         return "{\"error\": \"" & my escapeForJson(errMsg) & "\", \"errorNumber\": " & errNum & "}"
     end try

--- a/src/domains/accounts/scripts/list-accounts.applescript
+++ b/src/domains/accounts/scripts/list-accounts.applescript
@@ -15,6 +15,11 @@ tell application "Mail"
                 set acctType to "unknown"
             end if
             set acctEnabled to enabled of acct
+            set acctFullName to ""
+            try
+                set rawFullName to full name of acct
+                if rawFullName is not missing value then set acctFullName to my escapeForJson(rawFullName as text)
+            end try
             set acctEmails to email addresses of acct
             set emailsJson to ""
             repeat with i from 1 to count of acctEmails
@@ -22,7 +27,7 @@ tell application "Mail"
                 set emailsJson to emailsJson & "\"" & my escapeForJson(item i of acctEmails) & "\""
             end repeat
             if accountList is not "" then set accountList to accountList & ", "
-            set accountList to accountList & "{\"name\": \"" & acctName & "\", \"type\": \"" & acctType & "\", \"enabled\": " & acctEnabled & ", \"emails\": [" & emailsJson & "]}"
+            set accountList to accountList & "{\"name\": \"" & acctName & "\", \"type\": \"" & acctType & "\", \"enabled\": " & acctEnabled & ", \"fullName\": \"" & acctFullName & "\", \"emails\": [" & emailsJson & "]}"
         end repeat
         return "[" & accountList & "]"
     on error errMsg number errNum

--- a/src/domains/compose/compose.tools.ts
+++ b/src/domains/compose/compose.tools.ts
@@ -5,6 +5,19 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runAppleScript } from "../../bridge/applescript-runner.js";
 import { sanitize, toolError } from "../../utils.js";
+import { NO_SENDER, resolveSender } from "./sender.js";
+
+/**
+ * Resolve an optional caller-supplied account into the sentinel or sender string
+ * the AppleScript templates expect. Runs before any temp-file setup so a bad
+ * value fails without leaving a directory behind.
+ */
+async function senderParam(fromAccount?: string): Promise<string> {
+  if (fromAccount === undefined) {
+    return NO_SENDER;
+  }
+  return sanitize(await resolveSender(fromAccount));
+}
 
 export async function handleSendMessage(
   to: string,
@@ -12,8 +25,10 @@ export async function handleSendMessage(
   body: string,
   cc?: string,
   bcc?: string,
-  attachmentPaths?: string[]
+  attachmentPaths?: string[],
+  fromAccount?: string
 ): Promise<unknown> {
+  const sender = await senderParam(fromAccount);
   const tempDir = await mkdtemp(join(tmpdir(), "mail-mcp-body-"));
   try {
     // Write body to temp file so AppleScript can read it with proper newlines
@@ -32,6 +47,7 @@ export async function handleSendMessage(
       cc: cc !== undefined ? sanitize(String(cc)) : "__NONE__",
       bcc: bcc !== undefined ? sanitize(String(bcc)) : "__NONE__",
       attachmentPathsFile,
+      sender,
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -43,8 +59,10 @@ export async function handleReplyToMessage(
   mailboxName: string,
   accountName: string,
   body: string,
-  replyAll: boolean
+  replyAll: boolean,
+  fromAccount?: string
 ): Promise<unknown> {
+  const sender = await senderParam(fromAccount);
   const tempDir = await mkdtemp(join(tmpdir(), "mail-mcp-body-"));
   try {
     const bodyFile = join(tempDir, "body.txt");
@@ -55,6 +73,7 @@ export async function handleReplyToMessage(
       accountName: sanitize(String(accountName)),
       bodyFile,
       replyAll: String(replyAll),
+      sender,
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -66,8 +85,10 @@ export async function handleForwardMessage(
   mailboxName: string,
   accountName: string,
   to: string,
-  body?: string
+  body?: string,
+  fromAccount?: string
 ): Promise<unknown> {
+  const sender = await senderParam(fromAccount);
   let tempDir: string | undefined;
   if (body !== undefined) {
     tempDir = await mkdtemp(join(tmpdir(), "mail-mcp-body-"));
@@ -84,6 +105,7 @@ export async function handleForwardMessage(
       accountName: sanitize(String(accountName)),
       to: sanitize(String(to)),
       bodyFile,
+      sender,
     });
   } finally {
     if (tempDir) {
@@ -92,10 +114,16 @@ export async function handleForwardMessage(
   }
 }
 
+const FROM_ACCOUNT_DESC =
+  'Account to send from — a Mail account name ("Google") or one of its addresses ' +
+  '("you@gmail.com"), as reported by list_accounts. Matching is case-insensitive and ' +
+  "an unrecognised value is an error, never a silent fallback. Omit to use Mail's " +
+  "default sending account; either way the account used is returned as `sender`.";
+
 export function registerComposeTools(server: McpServer): void {
   server.tool(
     "send_message",
-    "Compose and send a new email message as plain text. Returns success when the message is queued for sending; actual delivery is not confirmed. Check Mail's Sent or Outbox mailbox to verify delivery.",
+    "Compose and send a new email message as plain text. Returns success when the message is queued for sending, along with the `sender` the message was sent from; actual delivery is not confirmed. Check Mail's Sent or Outbox mailbox to verify delivery.",
     {
       to: z.string().describe("The recipient email address"),
       subject: z.string().describe("The subject of the email"),
@@ -106,8 +134,9 @@ export function registerComposeTools(server: McpServer): void {
         .array(z.string())
         .optional()
         .describe("List of absolute file paths to attach (optional)"),
+      fromAccount: z.string().optional().describe(FROM_ACCOUNT_DESC),
     },
-    async ({ to, subject, body, cc, bcc, attachmentPaths }) => {
+    async ({ to, subject, body, cc, bcc, attachmentPaths, fromAccount }) => {
       try {
         const result = await handleSendMessage(
           to,
@@ -115,7 +144,8 @@ export function registerComposeTools(server: McpServer): void {
           body,
           cc,
           bcc,
-          attachmentPaths
+          attachmentPaths,
+          fromAccount
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -128,24 +158,31 @@ export function registerComposeTools(server: McpServer): void {
 
   server.tool(
     "reply_to_message",
-    "Reply to an existing email message. Does not support attachments (Mail.app limitation).",
+    "Reply to an existing email message. Returns the `sender` the reply was sent from. Does not support attachments (Mail.app limitation).",
     {
       messageId: z.number().int().describe("The numeric ID of the message to reply to"),
       mailboxName: z.string().describe("The name of the mailbox containing the message"),
-      accountName: z.string().describe("The name of the account containing the mailbox"),
+      accountName: z
+        .string()
+        .describe(
+          "The name of the account containing the mailbox. This locates the source " +
+            "message only — it does not control which account sends. Use fromAccount for that."
+        ),
       body: z.string().describe("The reply body text"),
       replyAll: z
         .boolean()
         .describe("Whether to reply to all recipients (true) or just the sender (false)"),
+      fromAccount: z.string().optional().describe(FROM_ACCOUNT_DESC),
     },
-    async ({ messageId, mailboxName, accountName, body, replyAll }) => {
+    async ({ messageId, mailboxName, accountName, body, replyAll, fromAccount }) => {
       try {
         const result = await handleReplyToMessage(
           messageId,
           mailboxName,
           accountName,
           body,
-          replyAll
+          replyAll,
+          fromAccount
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -158,25 +195,32 @@ export function registerComposeTools(server: McpServer): void {
 
   server.tool(
     "forward_message",
-    "Forward an existing email message to a new recipient. Does not support adding new attachments (Mail.app limitation).",
+    "Forward an existing email message to a new recipient. Returns the `sender` the forward was sent from. Does not support adding new attachments (Mail.app limitation).",
     {
       messageId: z.number().int().describe("The numeric ID of the message to forward"),
       mailboxName: z.string().describe("The name of the mailbox containing the message"),
-      accountName: z.string().describe("The name of the account containing the mailbox"),
+      accountName: z
+        .string()
+        .describe(
+          "The name of the account containing the mailbox. This locates the source " +
+            "message only — it does not control which account sends. Use fromAccount for that."
+        ),
       to: z.string().describe("The recipient email address to forward to"),
       body: z
         .string()
         .optional()
         .describe("Optional text to prepend to the forwarded message body"),
+      fromAccount: z.string().optional().describe(FROM_ACCOUNT_DESC),
     },
-    async ({ messageId, mailboxName, accountName, to, body }) => {
+    async ({ messageId, mailboxName, accountName, to, body, fromAccount }) => {
       try {
         const result = await handleForwardMessage(
           messageId,
           mailboxName,
           accountName,
           to,
-          body
+          body,
+          fromAccount
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/domains/compose/scripts/forward-message.applescript
+++ b/src/domains/compose/scripts/forward-message.applescript
@@ -9,13 +9,24 @@ tell application "Mail"
         set msg to (first message of theMailbox whose id is {{messageId}})
         set fwdMsg to forward msg without opening window
         tell fwdMsg
+            if "{{sender}}" is not "__NONE__" then
+                set sender to "{{sender}}"
+            end if
             make new to recipient with properties {address:"{{to}}"}
             if bodyContent is not "" then
                 set content to bodyContent & (ASCII character 10) & (ASCII character 10) & content
             end if
-            send
         end tell
-        return "{\"success\": true}"
+        -- Read back before sending. With no explicit sender this reveals whether
+        -- Mail inherited the account that received the original or fell back to
+        -- the global default.
+        set actualSender to ""
+        try
+            set rawSender to sender of fwdMsg
+            if rawSender is not missing value then set actualSender to (rawSender as text)
+        end try
+        send fwdMsg
+        return "{\"success\": true, \"sender\": \"" & my escapeForJson(actualSender) & "\"}"
     on error errMsg number errNum
         return "{\"error\": \"" & my escapeForJson(errMsg) & "\", \"errorNumber\": " & errNum & "}"
     end try

--- a/src/domains/compose/scripts/reply-to-message.applescript
+++ b/src/domains/compose/scripts/reply-to-message.applescript
@@ -13,12 +13,23 @@ tell application "Mail"
             set replyMsg to reply msg without opening window
         end if
         tell replyMsg
+            if "{{sender}}" is not "__NONE__" then
+                set sender to "{{sender}}"
+            end if
             if bodyContent is not "" then
                 set content to bodyContent & (ASCII character 10) & (ASCII character 10) & content
             end if
-            send
         end tell
-        return "{\"success\": true}"
+        -- Read back before sending. With no explicit sender this reveals whether
+        -- Mail inherited the account that received the original or fell back to
+        -- the global default.
+        set actualSender to ""
+        try
+            set rawSender to sender of replyMsg
+            if rawSender is not missing value then set actualSender to (rawSender as text)
+        end try
+        send replyMsg
+        return "{\"success\": true, \"sender\": \"" & my escapeForJson(actualSender) & "\"}"
     on error errMsg number errNum
         return "{\"error\": \"" & my escapeForJson(errMsg) & "\", \"errorNumber\": " & errNum & "}"
     end try

--- a/src/domains/compose/scripts/send-message.applescript
+++ b/src/domains/compose/scripts/send-message.applescript
@@ -6,6 +6,9 @@ tell application "Mail"
     try
         set newMsg to make new outgoing message with properties {content:bodyContent, subject:subjectText, visible:false}
         tell newMsg
+            if "{{sender}}" is not "__NONE__" then
+                set sender to "{{sender}}"
+            end if
             make new to recipient with properties {address:"{{to}}"}
             if "{{cc}}" is not "__NONE__" then
                 make new cc recipient with properties {address:"{{cc}}"}
@@ -23,9 +26,17 @@ tell application "Mail"
                     delay 1
                 end repeat
             end if
-            send
         end tell
-        return "{\"success\": true}"
+        -- Read the sender back before sending: when the caller passed no sender
+        -- this reports the account Mail chose on its own, which is otherwise
+        -- only discoverable by finding the message in Sent afterwards.
+        set actualSender to ""
+        try
+            set rawSender to sender of newMsg
+            if rawSender is not missing value then set actualSender to (rawSender as text)
+        end try
+        send newMsg
+        return "{\"success\": true, \"sender\": \"" & my escapeForJson(actualSender) & "\"}"
     on error errMsg number errNum
         return "{\"error\": \"" & my escapeForJson(errMsg) & "\", \"errorNumber\": " & errNum & "}"
     end try

--- a/src/domains/compose/sender.ts
+++ b/src/domains/compose/sender.ts
@@ -1,0 +1,88 @@
+// macos-mail-mcp — MIT License — https://github.com/marius-cetanas/macos-mail-mcp
+import { handleListAccounts } from "../accounts/accounts.tools.js";
+import type { Account } from "../../types.js";
+
+/** Sentinel the compose AppleScript templates read as "caller did not specify a sender". */
+export const NO_SENDER = "__NONE__";
+
+/**
+ * Build the string Mail expects in an outgoing message's `sender` property.
+ *
+ * Mail matches this against the account's configured identity, so the full
+ * `"Name <address>"` form is preferred. Accounts whose full name is unset fall
+ * back to the bare address, which Mail still resolves.
+ */
+export function formatSender(fullName: string, address: string): string {
+  const name = fullName.trim();
+  return name === "" ? address : `${name} <${address}>`;
+}
+
+/**
+ * Resolve a caller-supplied account name or email address to a sender string.
+ *
+ * Accepts either the Mail account name ("Google") or any address that account
+ * owns ("someone@gmail.com"), matched case-insensitively, mirroring how
+ * `list_accounts` reports them. Only enabled accounts are considered — Mail
+ * cannot send from a disabled one.
+ *
+ * @throws when the value matches no enabled account, or matches several that
+ * would resolve to different senders. Failing here is the point: the silent
+ * fallback to Mail's default account is the bug this guards against.
+ */
+export async function resolveSender(fromAccount: string): Promise<string> {
+  const needle = fromAccount.trim().toLowerCase();
+  if (needle === "") {
+    throw new Error("fromAccount must not be empty.");
+  }
+
+  const accounts = ((await handleListAccounts()) as Account[]).filter(
+    (a) => a.enabled
+  );
+
+  const matches: string[] = [];
+  for (const account of accounts) {
+    const addressHit = account.emails.find(
+      (email) => email.trim().toLowerCase() === needle
+    );
+    if (addressHit !== undefined) {
+      matches.push(formatSender(account.fullName, addressHit));
+      continue;
+    }
+    if (account.name.trim().toLowerCase() === needle) {
+      const primary = account.emails[0];
+      if (primary === undefined) {
+        throw new Error(
+          `Account "${account.name}" has no email addresses configured, so it cannot be used as a sender.`
+        );
+      }
+      matches.push(formatSender(account.fullName, primary));
+    }
+  }
+
+  const distinct = [...new Set(matches)];
+  if (distinct.length === 1) {
+    return distinct[0]!;
+  }
+  if (distinct.length > 1) {
+    throw new Error(
+      `"${fromAccount}" is ambiguous — it matches multiple senders: ${distinct.join(
+        ", "
+      )}. Pass a specific email address instead.`
+    );
+  }
+
+  throw new Error(
+    `"${fromAccount}" does not match any enabled Mail account. Valid values: ${describeChoices(
+      accounts
+    )}`
+  );
+}
+
+function describeChoices(accounts: Account[]): string {
+  if (accounts.length === 0) {
+    return "(no enabled accounts found in Mail)";
+  }
+  return accounts
+    .map((a) => `"${a.name}" (${a.emails.join(", ") || "no addresses"})`)
+    .join("; ");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface Account {
   name: string;
   type: "imap" | "pop" | "iCloud" | "unknown";
   enabled: boolean;
+  /** Display name Mail sends as, e.g. "Marius Cetanas". Empty when Mail reports `missing value`. */
+  fullName: string;
   emails: string[];
 }
 

--- a/tests/domains/accounts/accounts.registration.test.ts
+++ b/tests/domains/accounts/accounts.registration.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/bridge/applescript-runner.js", () => ({
+  runAppleScript: vi.fn(),
+  EXTENDED_TIMEOUT: 120_000,
+  DEFAULT_TIMEOUT: 30_000,
+}));
+
+import { runAppleScript } from "../../../src/bridge/applescript-runner.js";
+import { registerAccountsTools } from "../../../src/domains/accounts/accounts.tools.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+const ACCOUNT = {
+  name: "Google",
+  type: "imap",
+  enabled: true,
+  fullName: "Marius Cetanas",
+  emails: ["marius.cetanas@gmail.com"],
+};
+
+interface RegisteredTool {
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: true;
+  }>;
+}
+
+function captureTools(): Map<string, RegisteredTool> {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool: (
+      name: string,
+      description: string,
+      schema: Record<string, unknown>,
+      handler: RegisteredTool["handler"]
+    ) => {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  registerAccountsTools(server as never);
+  return tools;
+}
+
+describe("accounts tool registration", () => {
+  let tools: Map<string, RegisteredTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAppleScript.mockResolvedValue([ACCOUNT]);
+    tools = captureTools();
+  });
+
+  it("registers both account tools", () => {
+    expect([...tools.keys()].sort()).toEqual(["get_account_detail", "list_accounts"]);
+  });
+
+  describe("list_accounts", () => {
+    it("returns the account list, including the fullName senders are built from", async () => {
+      const result = await tools.get("list_accounts")!.handler({});
+      expect(JSON.parse(result.content[0]!.text)).toEqual([
+        expect.objectContaining({ name: "Google", fullName: "Marius Cetanas" }),
+      ]);
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("invokes the list-accounts script", async () => {
+      await tools.get("list_accounts")!.handler({});
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "accounts/scripts/list-accounts.applescript",
+        {}
+      );
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("Mail is not running"));
+      const result = await tools.get("list_accounts")!.handler({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Mail is not running/);
+    });
+  });
+
+  describe("get_account_detail", () => {
+    it("passes the requested account through", async () => {
+      mockRunAppleScript.mockResolvedValue(ACCOUNT);
+      await tools.get("get_account_detail")!.handler({ accountName: "Google" });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "accounts/scripts/get-account-detail.applescript",
+        { accountName: "Google" }
+      );
+    });
+
+    it("strips newlines from the account name", async () => {
+      mockRunAppleScript.mockResolvedValue(ACCOUNT);
+      await tools.get("get_account_detail")!.handler({ accountName: "Goo\ngle" });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "accounts/scripts/get-account-detail.applescript",
+        { accountName: "Goo gle" }
+      );
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("no such account"));
+      const result = await tools.get("get_account_detail")!.handler({
+        accountName: "Nope",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/no such account/);
+    });
+  });
+});

--- a/tests/domains/compose/compose.registration.test.ts
+++ b/tests/domains/compose/compose.registration.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/bridge/applescript-runner.js", () => ({
+  runAppleScript: vi.fn(),
+  EXTENDED_TIMEOUT: 120_000,
+  DEFAULT_TIMEOUT: 30_000,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdtemp: vi.fn().mockResolvedValue("/tmp/mail-mcp-body-abc123"),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runAppleScript } from "../../../src/bridge/applescript-runner.js";
+import { registerComposeTools } from "../../../src/domains/compose/compose.tools.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+const ACCOUNTS = [
+  {
+    name: "Google",
+    type: "imap",
+    enabled: true,
+    fullName: "Marius Cetanas",
+    emails: ["marius.cetanas@gmail.com"],
+  },
+];
+
+interface RegisteredTool {
+  description: string;
+  schema: Record<string, { isOptional(): boolean }>;
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: true;
+  }>;
+}
+
+/** Minimal stand-in for McpServer that captures what registerComposeTools registers. */
+function captureTools(): Map<string, RegisteredTool> {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool: (
+      name: string,
+      description: string,
+      schema: RegisteredTool["schema"],
+      handler: RegisteredTool["handler"]
+    ) => {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  registerComposeTools(server as never);
+  return tools;
+}
+
+/** Parse the JSON payload an MCP tool handler returns. */
+function payload(result: { content: Array<{ text: string }> }): unknown {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe("compose tool registration", () => {
+  let tools: Map<string, RegisteredTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAppleScript.mockImplementation(async (script: string) =>
+      script.includes("list-accounts")
+        ? ACCOUNTS
+        : { success: true, sender: "Marius Cetanas <marius.cetanas@gmail.com>" }
+    );
+    tools = captureTools();
+  });
+
+  it("registers all three compose tools", () => {
+    expect([...tools.keys()].sort()).toEqual([
+      "forward_message",
+      "reply_to_message",
+      "send_message",
+    ]);
+  });
+
+  describe.each(["send_message", "reply_to_message", "forward_message"])(
+    "%s",
+    (toolName) => {
+      it("exposes an optional fromAccount parameter", () => {
+        const schema = tools.get(toolName)!.schema;
+        expect(schema.fromAccount).toBeDefined();
+        expect(schema.fromAccount!.isOptional()).toBe(true);
+      });
+
+      it("documents that the resolved sender is returned", () => {
+        expect(tools.get(toolName)!.description).toMatch(/sender/i);
+      });
+
+      it("documents that an unknown fromAccount is an error, not a fallback", () => {
+        const described = JSON.stringify(tools.get(toolName)!.schema.fromAccount);
+        expect(described.length).toBeGreaterThan(0);
+      });
+    }
+  );
+
+  describe("reply_to_message and forward_message accountName", () => {
+    it.each(["reply_to_message", "forward_message"])(
+      "%s documents accountName as a lookup, not a sender selector",
+      (toolName) => {
+        const schema = tools.get(toolName)!.schema as unknown as Record<
+          string,
+          { description?: string }
+        >;
+        expect(schema.accountName!.description).toMatch(/does not control which account sends/);
+      }
+    );
+  });
+
+  describe("send_message handler", () => {
+    it("returns the resolved sender in the result", async () => {
+      const result = await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+        fromAccount: "Google",
+      });
+      expect(payload(result)).toMatchObject({
+        success: true,
+        sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+      });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("reports the sender even when fromAccount was omitted", async () => {
+      const result = await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+      });
+      expect(payload(result)).toMatchObject({ sender: expect.any(String) });
+    });
+
+    it("forwards fromAccount down to the compose script", async () => {
+      await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+        fromAccount: "marius.cetanas@gmail.com",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "compose/scripts/send-message.applescript",
+        expect.objectContaining({ sender: "Marius Cetanas <marius.cetanas@gmail.com>" })
+      );
+    });
+
+    it("returns an MCP error for an unknown fromAccount", async () => {
+      const result = await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+        fromAccount: "typo@example.com",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/does not match any enabled Mail account/);
+    });
+
+    it("names the valid accounts in the error text", async () => {
+      const result = await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+        fromAccount: "typo@example.com",
+      });
+      expect(result.content[0]!.text).toMatch(/Google/);
+    });
+
+    it("surfaces a compose failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("Mail is not running"));
+      const result = await tools.get("send_message")!.handler({
+        to: "bob@test.com",
+        subject: "Hi",
+        body: "Hello",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Mail is not running/);
+    });
+  });
+
+  describe("reply_to_message handler", () => {
+    const base = {
+      messageId: 123,
+      mailboxName: "INBOX",
+      accountName: "Gmail",
+      body: "Thanks!",
+      replyAll: false,
+    };
+
+    it("returns the resolved sender", async () => {
+      const result = await tools.get("reply_to_message")!.handler({
+        ...base,
+        fromAccount: "Google",
+      });
+      expect(payload(result)).toMatchObject({
+        sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+      });
+    });
+
+    it("keeps the lookup account separate from the sender", async () => {
+      await tools.get("reply_to_message")!.handler({ ...base, fromAccount: "Google" });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "compose/scripts/reply-to-message.applescript",
+        expect.objectContaining({
+          accountName: "Gmail",
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        })
+      );
+    });
+
+    it("returns an MCP error for an unknown fromAccount", async () => {
+      const result = await tools.get("reply_to_message")!.handler({
+        ...base,
+        fromAccount: "typo@example.com",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("forward_message handler", () => {
+    const base = {
+      messageId: 123,
+      mailboxName: "INBOX",
+      accountName: "Gmail",
+      to: "alice@test.com",
+    };
+
+    it("returns the resolved sender", async () => {
+      const result = await tools.get("forward_message")!.handler({
+        ...base,
+        fromAccount: "Google",
+      });
+      expect(payload(result)).toMatchObject({
+        sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+      });
+    });
+
+    it("resolves the sender when a body is supplied", async () => {
+      await tools.get("forward_message")!.handler({
+        ...base,
+        body: "FYI",
+        fromAccount: "Google",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "compose/scripts/forward-message.applescript",
+        expect.objectContaining({
+          bodyFile: expect.stringMatching(/^\//),
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        })
+      );
+    });
+
+    it("returns an MCP error for an unknown fromAccount", async () => {
+      const result = await tools.get("forward_message")!.handler({
+        ...base,
+        fromAccount: "typo@example.com",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/tests/domains/compose/compose.scripts.test.ts
+++ b/tests/domains/compose/compose.scripts.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+vi.mock("../../../src/bridge/applescript-runner.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../src/bridge/applescript-runner.js")
+  >();
+  return { ...actual, runAppleScript: vi.fn() };
+});
+
+import {
+  runAppleScript,
+  substituteParams,
+} from "../../../src/bridge/applescript-runner.js";
+import {
+  handleSendMessage,
+  handleReplyToMessage,
+  handleForwardMessage,
+} from "../../../src/domains/compose/compose.tools.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+const SCRIPT_DIR = join(process.cwd(), "src/domains/compose/scripts");
+
+const ACCOUNTS = [
+  {
+    name: "Google",
+    type: "imap",
+    enabled: true,
+    fullName: "Marius Cetanas",
+    emails: ["marius.cetanas@gmail.com"],
+  },
+];
+
+function scriptSource(name: string): string {
+  return readFileSync(join(SCRIPT_DIR, name), "utf8");
+}
+
+function placeholders(source: string): Set<string> {
+  return new Set(
+    [...source.matchAll(/\{\{(\w+)\}\}/g)].map((match) => match[1]!)
+  );
+}
+
+/** Invoke a handler and return the params it handed to the bridge. */
+async function paramsFor(
+  invoke: () => Promise<unknown>,
+  scriptFragment: string
+): Promise<Record<string, string>> {
+  await invoke();
+  const call = mockRunAppleScript.mock.calls.find(([script]) =>
+    String(script).includes(scriptFragment)
+  );
+  return (call?.[1] ?? {}) as Record<string, string>;
+}
+
+const CASES = [
+  {
+    file: "send-message.applescript",
+    invoke: () =>
+      handleSendMessage(
+        "bob@test.com", "Hi", "Hello",
+        "cc@t.com", "bcc@t.com", ["/tmp/a.pdf"], "Google"
+      ),
+  },
+  {
+    file: "reply-to-message.applescript",
+    invoke: () => handleReplyToMessage(1, "INBOX", "Gmail", "Thanks", true, "Google"),
+  },
+  {
+    file: "forward-message.applescript",
+    invoke: () => handleForwardMessage(1, "INBOX", "Gmail", "a@t.com", "FYI", "Google"),
+  },
+];
+
+describe("compose AppleScript templates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAppleScript.mockImplementation(async (script: string) =>
+      script.includes("list-accounts") ? ACCOUNTS : { success: true }
+    );
+  });
+
+  describe.each(CASES)("$file", ({ file, invoke }) => {
+    it("declares a {{sender}} placeholder", () => {
+      expect(placeholders(scriptSource(file))).toContain("sender");
+    });
+
+    it("guards the assignment behind the __NONE__ sentinel", () => {
+      expect(scriptSource(file)).toMatch(
+        /if "\{\{sender\}\}" is not "__NONE__" then\s*\n\s*set sender to "\{\{sender\}\}"/
+      );
+    });
+
+    it("reads the sender back and returns it on success", () => {
+      const source = scriptSource(file);
+      expect(source).toMatch(/set rawSender to sender of \w+/);
+      expect(source).toContain('\\"success\\": true, \\"sender\\": \\""');
+      expect(source).toContain("escapeForJson(actualSender)");
+    });
+
+    it("reads the sender back before sending, not after", () => {
+      const source = scriptSource(file);
+      expect(source.indexOf("set rawSender to")).toBeLessThan(source.indexOf("send "));
+    });
+
+    it("escapes the sender for JSON output", () => {
+      expect(scriptSource(file)).toMatch(/escapeForJson\(actualSender\)/);
+    });
+
+    it("tolerates Mail returning 'missing value' for the sender", () => {
+      expect(scriptSource(file)).toMatch(/if rawSender is not missing value then/);
+    });
+
+    it("has every placeholder supplied by its handler", async () => {
+      const supplied = new Set(Object.keys(await paramsFor(invoke, file.replace(".applescript", ""))));
+      const missing = [...placeholders(scriptSource(file))].filter(
+        (name) => !supplied.has(name)
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("leaves no unsubstituted placeholder after substitution", async () => {
+      const params = await paramsFor(invoke, file.replace(".applescript", ""));
+      const rendered = substituteParams(scriptSource(file), params);
+      expect(rendered).not.toMatch(/\{\{\w+\}\}/);
+    });
+
+    it("renders the resolved sender into the script body", async () => {
+      const params = await paramsFor(invoke, file.replace(".applescript", ""));
+      const rendered = substituteParams(scriptSource(file), params);
+      expect(rendered).toContain('set sender to "Marius Cetanas <marius.cetanas@gmail.com>"');
+    });
+
+    it("renders the sentinel unchanged when no account was requested", async () => {
+      const noSender = await paramsFor(
+        () =>
+          file.startsWith("send")
+            ? handleSendMessage("bob@test.com", "Hi", "Hello")
+            : file.startsWith("reply")
+              ? handleReplyToMessage(1, "INBOX", "Gmail", "Thanks", true)
+              : handleForwardMessage(1, "INBOX", "Gmail", "a@t.com"),
+        file.replace(".applescript", "")
+      );
+      expect(noSender.sender).toBe("__NONE__");
+      const rendered = substituteParams(scriptSource(file), noSender);
+      expect(rendered).toContain('if "__NONE__" is not "__NONE__" then');
+    });
+  });
+
+  describe("accounts templates expose the full name needed to build a sender", () => {
+    it.each(["list-accounts.applescript", "get-account-detail.applescript"])(
+      "%s emits a fullName field",
+      (file) => {
+        const source = readFileSync(
+          join(process.cwd(), "src/domains/accounts/scripts", file),
+          "utf8"
+        );
+        expect(source).toMatch(/full name of acct/);
+        expect(source).toMatch(/\\"fullName\\": \\""/);
+      }
+    );
+
+    it.each(["list-accounts.applescript", "get-account-detail.applescript"])(
+      "%s tolerates a missing full name",
+      (file) => {
+        const source = readFileSync(
+          join(process.cwd(), "src/domains/accounts/scripts", file),
+          "utf8"
+        );
+        expect(source).toMatch(/if rawFullName is not missing value then/);
+      }
+    );
+  });
+});

--- a/tests/domains/compose/compose.tools.test.ts
+++ b/tests/domains/compose/compose.tools.test.ts
@@ -108,4 +108,214 @@ describe("compose tools", () => {
       expect.objectContaining({ mailboxName: "[Gmail]/Sent Mail", accountName: "Gmail", to: "alice@test.com" })
     );
   });
+
+  describe("sender selection", () => {
+    const ACCOUNTS = [
+      {
+        name: "Google",
+        type: "imap",
+        enabled: true,
+        fullName: "Marius Cetanas",
+        emails: ["marius.cetanas@gmail.com"],
+      },
+      {
+        name: "iCloud",
+        type: "iCloud",
+        enabled: true,
+        fullName: "Marius Cetanas",
+        emails: ["marius.cetanas@icloud.com"],
+      },
+    ];
+
+    /** Route list-accounts to fixture data, everything else to a success result. */
+    function routeAccounts(accounts: unknown = ACCOUNTS): void {
+      mockRunAppleScript.mockImplementation(async (script: string) =>
+        script.includes("list-accounts") ? accounts : { success: true }
+      );
+    }
+
+    function composeCall(scriptFragment: string) {
+      return mockRunAppleScript.mock.calls.find(([script]) =>
+        String(script).includes(scriptFragment)
+      );
+    }
+
+    describe("defaults to Mail's own account when fromAccount is omitted", () => {
+      it("send_message passes the __NONE__ sentinel", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage("bob@test.com", "Hi", "Hello");
+        expect(mockRunAppleScript).toHaveBeenCalledWith(
+          "compose/scripts/send-message.applescript",
+          expect.objectContaining({ sender: "__NONE__" })
+        );
+      });
+
+      it("reply_to_message passes the __NONE__ sentinel", async () => {
+        const { handleReplyToMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleReplyToMessage(123, "INBOX", "Gmail", "Thanks!", false);
+        expect(mockRunAppleScript).toHaveBeenCalledWith(
+          "compose/scripts/reply-to-message.applescript",
+          expect.objectContaining({ sender: "__NONE__" })
+        );
+      });
+
+      it("forward_message passes the __NONE__ sentinel", async () => {
+        const { handleForwardMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleForwardMessage(123, "INBOX", "Gmail", "alice@test.com");
+        expect(mockRunAppleScript).toHaveBeenCalledWith(
+          "compose/scripts/forward-message.applescript",
+          expect.objectContaining({ sender: "__NONE__" })
+        );
+      });
+
+      it("does not consult list_accounts", async () => {
+        routeAccounts();
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage("bob@test.com", "Hi", "Hello");
+        expect(composeCall("list-accounts")).toBeUndefined();
+      });
+    });
+
+    describe("resolves fromAccount to a sender string", () => {
+      beforeEach(() => routeAccounts());
+
+      it("send_message resolves an account name", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "Google");
+        expect(composeCall("send-message")?.[1]).toMatchObject({
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("send_message resolves an email address", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage(
+          "bob@test.com", "Hi", "Hello", undefined, undefined, undefined,
+          "marius.cetanas@icloud.com"
+        );
+        expect(composeCall("send-message")?.[1]).toMatchObject({
+          sender: "Marius Cetanas <marius.cetanas@icloud.com>",
+        });
+      });
+
+      it("send_message keeps other params intact alongside the sender", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage("bob@test.com", "Hi", "Hello", "cc@t.com", "bcc@t.com", undefined, "Google");
+        expect(composeCall("send-message")?.[1]).toMatchObject({
+          to: "bob@test.com",
+          cc: "cc@t.com",
+          bcc: "bcc@t.com",
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("reply_to_message resolves the sender", async () => {
+        const { handleReplyToMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleReplyToMessage(123, "INBOX", "Gmail", "Thanks!", true, "Google");
+        expect(composeCall("reply-to-message")?.[1]).toMatchObject({
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("reply_to_message sender is independent of the lookup accountName", async () => {
+        const { handleReplyToMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleReplyToMessage(123, "INBOX", "iCloud", "Thanks!", false, "Google");
+        expect(composeCall("reply-to-message")?.[1]).toMatchObject({
+          accountName: "iCloud",
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("forward_message resolves the sender", async () => {
+        const { handleForwardMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleForwardMessage(123, "INBOX", "Gmail", "alice@test.com", undefined, "Google");
+        expect(composeCall("forward-message")?.[1]).toMatchObject({
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("forward_message resolves the sender when a body is supplied", async () => {
+        const { handleForwardMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleForwardMessage(123, "INBOX", "Gmail", "alice@test.com", "FYI", "Google");
+        expect(composeCall("forward-message")?.[1]).toMatchObject({
+          bodyFile: expect.stringMatching(/^\//),
+          sender: "Marius Cetanas <marius.cetanas@gmail.com>",
+        });
+      });
+
+      it("strips newlines that would break the AppleScript string literal", async () => {
+        routeAccounts([
+          { name: "Odd", type: "imap", enabled: true, fullName: "Marius\nCetanas", emails: ["m@x.com"] },
+        ]);
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "Odd");
+        expect(composeCall("send-message")?.[1]).toMatchObject({
+          sender: "Marius Cetanas <m@x.com>",
+        });
+      });
+    });
+
+    describe("rejects an unresolvable fromAccount", () => {
+      beforeEach(() => routeAccounts());
+
+      it("send_message throws instead of falling back", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "typo@x.com")
+        ).rejects.toThrow(/does not match any enabled Mail account/);
+      });
+
+      it("send_message never reaches the compose script", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "typo@x.com")
+        ).rejects.toThrow();
+        expect(composeCall("send-message")).toBeUndefined();
+      });
+
+      it("send_message leaves no temp directory behind", async () => {
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "typo@x.com")
+        ).rejects.toThrow();
+        expect(mockMkdtemp).not.toHaveBeenCalled();
+      });
+
+      it("reply_to_message throws and never reaches the compose script", async () => {
+        const { handleReplyToMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleReplyToMessage(123, "INBOX", "Gmail", "Thanks!", false, "typo@x.com")
+        ).rejects.toThrow();
+        expect(composeCall("reply-to-message")).toBeUndefined();
+        expect(mockMkdtemp).not.toHaveBeenCalled();
+      });
+
+      it("forward_message throws and never reaches the compose script", async () => {
+        const { handleForwardMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleForwardMessage(123, "INBOX", "Gmail", "alice@test.com", "FYI", "typo@x.com")
+        ).rejects.toThrow();
+        expect(composeCall("forward-message")).toBeUndefined();
+        expect(mockMkdtemp).not.toHaveBeenCalled();
+      });
+
+      it("rejects a disabled account", async () => {
+        routeAccounts([
+          { name: "Off", type: "imap", enabled: false, fullName: "M", emails: ["off@x.com"] },
+        ]);
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "off@x.com")
+        ).rejects.toThrow(/does not match any enabled Mail account/);
+      });
+
+      it("propagates a failure to read the account list", async () => {
+        mockRunAppleScript.mockRejectedValue(new Error("Mail is not running"));
+        const { handleSendMessage } = await import("../../../src/domains/compose/compose.tools.js");
+        await expect(
+          handleSendMessage("bob@test.com", "Hi", "Hello", undefined, undefined, undefined, "Google")
+        ).rejects.toThrow(/Mail is not running/);
+      });
+    });
+  });
 });

--- a/tests/domains/compose/sender.test.ts
+++ b/tests/domains/compose/sender.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/bridge/applescript-runner.js", () => ({
+  runAppleScript: vi.fn(),
+  EXTENDED_TIMEOUT: 120_000,
+  DEFAULT_TIMEOUT: 30_000,
+}));
+
+import { runAppleScript } from "../../../src/bridge/applescript-runner.js";
+import { formatSender, resolveSender, NO_SENDER } from "../../../src/domains/compose/sender.js";
+import type { Account } from "../../../src/types.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+function account(overrides: Partial<Account> = {}): Account {
+  return {
+    name: "Google",
+    type: "imap",
+    enabled: true,
+    fullName: "Marius Cetanas",
+    emails: ["marius.cetanas@gmail.com"],
+    ...overrides,
+  };
+}
+
+/** Make list_accounts resolve to the given accounts. */
+function withAccounts(...accounts: Account[]): void {
+  mockRunAppleScript.mockResolvedValue(accounts);
+}
+
+describe("formatSender", () => {
+  it("builds the full 'Name <address>' form", () => {
+    expect(formatSender("Marius Cetanas", "m@example.com")).toBe(
+      "Marius Cetanas <m@example.com>"
+    );
+  });
+
+  it("falls back to a bare address when the full name is empty", () => {
+    expect(formatSender("", "m@example.com")).toBe("m@example.com");
+  });
+
+  it("treats a whitespace-only full name as absent", () => {
+    expect(formatSender("   ", "m@example.com")).toBe("m@example.com");
+  });
+
+  it("trims surrounding whitespace from the full name", () => {
+    expect(formatSender("  Marius  ", "m@example.com")).toBe("Marius <m@example.com>");
+  });
+});
+
+describe("NO_SENDER", () => {
+  it("matches the sentinel the AppleScript templates compare against", () => {
+    expect(NO_SENDER).toBe("__NONE__");
+  });
+});
+
+describe("resolveSender", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("matching by account name", () => {
+    it("resolves an exact account name", async () => {
+      withAccounts(account());
+      await expect(resolveSender("Google")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+
+    it("matches case-insensitively", async () => {
+      withAccounts(account());
+      await expect(resolveSender("gOOgLe")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+
+    it("ignores surrounding whitespace in the input", async () => {
+      withAccounts(account());
+      await expect(resolveSender("  Google  ")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+
+    it("uses the first address when an account has several", async () => {
+      withAccounts(
+        account({ emails: ["primary@gmail.com", "alias@gmail.com"] })
+      );
+      await expect(resolveSender("Google")).resolves.toBe(
+        "Marius Cetanas <primary@gmail.com>"
+      );
+    });
+
+    it("rejects an account that has no addresses configured", async () => {
+      withAccounts(account({ emails: [] }));
+      await expect(resolveSender("Google")).rejects.toThrow(
+        /has no email addresses configured/
+      );
+    });
+  });
+
+  describe("matching by email address", () => {
+    it("resolves an exact address", async () => {
+      withAccounts(account());
+      await expect(resolveSender("marius.cetanas@gmail.com")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+
+    it("matches case-insensitively", async () => {
+      withAccounts(account());
+      await expect(resolveSender("Marius.Cetanas@GMAIL.com")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+
+    it("resolves to the matched alias, not the account's first address", async () => {
+      withAccounts(
+        account({ emails: ["primary@gmail.com", "alias@gmail.com"] })
+      );
+      await expect(resolveSender("alias@gmail.com")).resolves.toBe(
+        "Marius Cetanas <alias@gmail.com>"
+      );
+    });
+
+    it("preserves the casing Mail reports, not the caller's", async () => {
+      withAccounts(account({ emails: ["Marius.Cetanas@Gmail.com"] }));
+      await expect(resolveSender("marius.cetanas@gmail.com")).resolves.toBe(
+        "Marius Cetanas <Marius.Cetanas@Gmail.com>"
+      );
+    });
+
+    it("picks the right account when several are configured", async () => {
+      withAccounts(
+        account({ name: "iCloud", emails: ["m@icloud.com"] }),
+        account({ name: "Google", emails: ["m@gmail.com"] })
+      );
+      await expect(resolveSender("m@gmail.com")).resolves.toBe(
+        "Marius Cetanas <m@gmail.com>"
+      );
+    });
+  });
+
+  describe("accounts with no full name", () => {
+    it("resolves to a bare address", async () => {
+      withAccounts(account({ fullName: "" }));
+      await expect(resolveSender("Google")).resolves.toBe("marius.cetanas@gmail.com");
+    });
+  });
+
+  describe("disabled accounts", () => {
+    it("does not match a disabled account by name", async () => {
+      withAccounts(account({ enabled: false }));
+      await expect(resolveSender("Google")).rejects.toThrow(
+        /does not match any enabled Mail account/
+      );
+    });
+
+    it("does not match a disabled account by address", async () => {
+      withAccounts(account({ enabled: false }));
+      await expect(resolveSender("marius.cetanas@gmail.com")).rejects.toThrow(
+        /does not match any enabled Mail account/
+      );
+    });
+
+    it("omits disabled accounts from the list of valid values", async () => {
+      withAccounts(
+        account({ name: "Disabled", enabled: false, emails: ["off@example.com"] }),
+        account({ name: "Google", emails: ["on@example.com"] })
+      );
+      await expect(resolveSender("nope")).rejects.toThrow(/on@example.com/);
+      await expect(resolveSender("nope")).rejects.not.toThrow(/off@example.com/);
+    });
+  });
+
+  describe("invalid input", () => {
+    it("rejects an empty string", async () => {
+      withAccounts(account());
+      await expect(resolveSender("")).rejects.toThrow(/must not be empty/);
+    });
+
+    it("rejects a whitespace-only string", async () => {
+      withAccounts(account());
+      await expect(resolveSender("   ")).rejects.toThrow(/must not be empty/);
+    });
+
+    it("does not consult Mail when the input is empty", async () => {
+      withAccounts(account());
+      await expect(resolveSender("")).rejects.toThrow();
+      expect(mockRunAppleScript).not.toHaveBeenCalled();
+    });
+
+    it("never silently falls back to the default account", async () => {
+      withAccounts(account());
+      await expect(resolveSender("typo@example.com")).rejects.toThrow();
+    });
+
+    it("names the offending value in the error", async () => {
+      withAccounts(account());
+      await expect(resolveSender("typo@example.com")).rejects.toThrow(
+        /"typo@example\.com"/
+      );
+    });
+
+    it("lists the valid choices in the error", async () => {
+      withAccounts(account({ name: "Google", emails: ["a@x.com", "b@x.com"] }));
+      await expect(resolveSender("nope")).rejects.toThrow(/"Google" \(a@x\.com, b@x\.com\)/);
+    });
+
+    it("reports when Mail has no enabled accounts at all", async () => {
+      withAccounts();
+      await expect(resolveSender("anything")).rejects.toThrow(
+        /no enabled accounts found in Mail/
+      );
+    });
+
+    it("describes an address-less account in the choices", async () => {
+      withAccounts(account({ name: "Empty", emails: [] }));
+      await expect(resolveSender("nope")).rejects.toThrow(/"Empty" \(no addresses\)/);
+    });
+  });
+
+  describe("ambiguity", () => {
+    it("rejects a value matching two accounts with different senders", async () => {
+      withAccounts(
+        account({ name: "Work", fullName: "M C", emails: ["shared@example.com"] }),
+        account({ name: "Personal", fullName: "Marius", emails: ["shared@example.com"] })
+      );
+      await expect(resolveSender("shared@example.com")).rejects.toThrow(/is ambiguous/);
+    });
+
+    it("lists both candidates in the ambiguity error", async () => {
+      withAccounts(
+        account({ name: "Work", fullName: "M C", emails: ["shared@example.com"] }),
+        account({ name: "Personal", fullName: "Marius", emails: ["shared@example.com"] })
+      );
+      await expect(resolveSender("shared@example.com")).rejects.toThrow(
+        /M C <shared@example\.com>.*Marius <shared@example\.com>/
+      );
+    });
+
+    it("accepts duplicates that resolve to the same sender", async () => {
+      withAccounts(
+        account({ name: "Work", fullName: "Marius", emails: ["shared@example.com"] }),
+        account({ name: "Mirror", fullName: "Marius", emails: ["shared@example.com"] })
+      );
+      await expect(resolveSender("shared@example.com")).resolves.toBe(
+        "Marius <shared@example.com>"
+      );
+    });
+
+    it("prefers an address match over a same-string name match on one account", async () => {
+      withAccounts(account({ name: "marius.cetanas@gmail.com" }));
+      await expect(resolveSender("marius.cetanas@gmail.com")).resolves.toBe(
+        "Marius Cetanas <marius.cetanas@gmail.com>"
+      );
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     globals: true,
     root: ".",
     restoreMocks: true,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      reporter: ["text", "html"],
+    },
   },
 });


### PR DESCRIPTION
Closes #4.

## What changed

`send_message`, `reply_to_message` and `forward_message` take an optional `fromAccount` — either a Mail account name (`"Google"`) or any address that account owns, matched case-insensitively against the **enabled** accounts. An unrecognised value throws an error naming the valid accounts; it never falls back to the default, since the silent fallback is the bug.

All three now also return the account actually used:

```json
{ "success": true, "sender": "Marius Cetanas <marius.cetanas@gmail.com>" }
```

That part matters more than the override. Each script reads `sender` back off the message *before* `send`, so the result reports Mail's own choice even when no `fromAccount` was passed — the wrong sending account becomes visible immediately instead of only turning up later in a Sent mailbox.

## Notes to self

- **Item 3 of the issue is deliberately not implemented.** Whether an unqualified reply or forward inherits the receiving account or falls back to the global default is still unconfirmed, and changing the default on an assumption risks breaking the case where Mail already does the right thing. The returned `sender` answers the question on the next real reply, and the default can change once it's known.
- **`fullName` was an unlisted dependency.** The `"Name <address>"` string needs `full name of acct`, which neither `list-accounts` nor the `Account` type exposed. Both now report it, wrapped in `try` since Mail can return `missing value` — in which case the sender degrades to a bare address, which Mail also accepts.
- **`accountName` on reply/forward stays a lookup param.** It feeds `resolveMailbox()` to find the source message and never controlled sending. Renaming it would be a breaking change, so its description now says so explicitly.
- Resolution runs before any temp-file setup, so a bad `fromAccount` fails without leaving a temp directory behind.

## Testing

189 tests, up from 74. The five changed source files are at 100% statements, branches, functions and lines:

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `sender.ts` | 100 | 100 | 100 | 100 |
| `compose.tools.ts` | 100 | 100 | 100 | 100 |
| `accounts.tools.ts` | 100 | 100 | 100 | 100 |
| `types.ts` | 100 | 100 | 100 | 100 |
| `utils.ts` | 100 | 100 | 100 | 100 |

Coverage is error-path-first, not just happy path: unknown account, disabled account, ambiguous match, empty input, account with no addresses, alias resolving to the matched address rather than the first, casing preserved as Mail reports it, `fullName` missing, newlines stripped from the sender, and a failure to read the account list propagating.

Three test layers were added:

- `sender.test.ts` — resolution and rejection rules in isolation.
- `compose.registration.test.ts` / `accounts.registration.test.ts` — drive the real MCP tool handlers through a stub server, covering the registration layer the repo had never exercised (it was 16–35%).
- `compose.scripts.test.ts` — a contract test over the `.applescript` templates: every `{{placeholder}}` must be supplied by its handler, and substitution must leave none behind. This catches the specific bug of adding a placeholder and forgetting to pass it, which would otherwise ship a literal `{{sender}}` into the script.

Beyond the suite, all five templates were verified to compile via `osacompile`, including a sender containing embedded double quotes, which exercises the escaping path end-to-end. `substituteParams` already routes every value through `escapeForAppleScript`, and the sender is `sanitize()`d, so quotes, backslashes and newlines are all handled.

Tooling: added `@vitest/coverage-v8` and an `npm run test:coverage` script; `coverage/` is gitignored.

## Not covered here

`index.ts`, the `osascript` subprocess path in `applescript-runner.ts`, and the `mailboxes`/`messages` registration layers are untouched by this change and still uncovered. Those are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
