### PR TITLE
test: cover the registration, bridge execution and entry-point layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      # Coverage rather than plain test: the config sets 100% thresholds, so
+      # this is what actually enforces them.
+      - run: npm run test:coverage
 
   audit:
     name: audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message only. It never controlled which account sends, and the name invited the opposite
   assumption; `fromAccount` is the sender selector.
 
+### Internal
+
+- Test suite raised from 74 to 280 tests, reaching 100% statement, branch, function and line
+  coverage of `src/`. The MCP registration layer — the tool handlers themselves, as opposed to the
+  `handleXxx` functions beneath them — had never been exercised, nor had the `osascript` execution
+  path in the bridge or the entry point. Coverage thresholds are set to 100% and CI runs
+  `test:coverage`, so untested new code fails the build instead of quietly lowering the number.
+
 ### Notes
 
 - Whether an unqualified reply or forward inherits the account that received the original message

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Works with **any email account configured in Mail.app** — iCloud, Gmail, Outlo
 - **MCP SDK:** `@modelcontextprotocol/sdk` v1.x (stdio transport)
 - **Mail integration:** AppleScript via `osascript` (execFile, not exec — prevents shell injection)
 - **Validation:** Zod schemas on all tool inputs
-- **Testing:** Vitest (189 unit tests, mocked bridge — no real Mail.app needed)
+- **Testing:** Vitest (280 unit tests at 100% coverage, mocked bridge — no real Mail.app needed)
 
 ## Architecture
 
@@ -140,8 +140,8 @@ ISO 8601 dates are converted to seconds-from-now in TypeScript (`dateToSecondsFr
 
 ```bash
 npm run build        # tsc + copy .applescript files to build/
-npm test             # Run 189 unit tests
-npm run test:coverage # Run tests with a v8 coverage report
+npm test             # Run 280 unit tests
+npm run test:coverage # Tests + coverage; fails below the 100% thresholds
 npm run test:watch   # Watch mode
 npm run dev          # TypeScript watch mode
 ```

--- a/tests/bridge/applescript-runner.run.test.ts
+++ b/tests/bridge/applescript-runner.run.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// execFileAsync is promisify(execFile) at module load, so the mock must carry a
+// promisify.custom hook — otherwise promisify wraps it callback-style and the
+// {stdout, stderr} shape is lost. Both values are hoisted because vi.mock
+// factories are lifted above ordinary top-level declarations.
+const { mockExec, PROMISIFY_CUSTOM } = vi.hoisted(() => ({
+  mockExec:
+    vi.fn<(cmd: string, args: string[], opts: { timeout: number }) => Promise<{ stdout: string; stderr: string }>>(),
+  PROMISIFY_CUSTOM: Symbol.for("nodejs.util.promisify.custom"),
+}));
+
+vi.mock("node:child_process", () => {
+  const execFile = ((..._args: unknown[]) => undefined) as unknown as Record<symbol, unknown>;
+  execFile[PROMISIFY_CUSTOM] = (cmd: string, args: string[], opts: { timeout: number }) =>
+    mockExec(cmd, args, opts);
+  return { execFile };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdtemp: vi.fn().mockResolvedValue("/tmp/macos-mail-mcp-test"),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { readFile, writeFile, mkdtemp, rm } from "node:fs/promises";
+import {
+  runAppleScript,
+  DEFAULT_TIMEOUT,
+  SHARED_HANDLER_FILES,
+} from "../../src/bridge/applescript-runner.js";
+
+const mockReadFile = vi.mocked(readFile);
+const mockWriteFile = vi.mocked(writeFile);
+const mockMkdtemp = vi.mocked(mkdtemp);
+const mockRm = vi.mocked(rm);
+
+/** The script text handed to osascript. */
+function writtenScript(): string {
+  return String(mockWriteFile.mock.calls[0]![1]);
+}
+
+describe("runAppleScript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Shared handlers first (in SHARED_HANDLER_FILES order), then the template.
+    mockReadFile.mockImplementation(async (path: unknown) => {
+      const p = String(path);
+      const shared = SHARED_HANDLER_FILES.find((f) => p.endsWith(f));
+      return shared ? `-- handler ${shared}` : "-- template {{name}}";
+    });
+    mockMkdtemp.mockResolvedValue("/tmp/macos-mail-mcp-test" as never);
+    mockWriteFile.mockResolvedValue(undefined);
+    mockRm.mockResolvedValue(undefined);
+    mockExec.mockResolvedValue({ stdout: '{"ok": true}', stderr: "" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("happy path", () => {
+    it("returns the parsed AppleScript output", async () => {
+      await expect(runAppleScript("accounts/scripts/x.applescript")).resolves.toEqual({
+        ok: true,
+      });
+    });
+
+    it("runs osascript against the temp script file", async () => {
+      await runAppleScript("accounts/scripts/x.applescript");
+      expect(mockExec).toHaveBeenCalledWith(
+        "osascript",
+        ["/tmp/macos-mail-mcp-test/script.applescript"],
+        expect.objectContaining({ timeout: DEFAULT_TIMEOUT })
+      );
+    });
+
+    it("prepends every shared handler ahead of the template", async () => {
+      await runAppleScript("accounts/scripts/x.applescript");
+      const script = writtenScript();
+      for (const handler of SHARED_HANDLER_FILES) {
+        expect(script).toContain(`-- handler ${handler}`);
+      }
+      expect(script.indexOf("-- handler")).toBeLessThan(script.indexOf("-- template"));
+    });
+
+    it("substitutes params when given", async () => {
+      await runAppleScript("accounts/scripts/x.applescript", { name: "Google" });
+      expect(writtenScript()).toContain("-- template Google");
+    });
+
+    it("leaves the template untouched when no params are given", async () => {
+      await runAppleScript("accounts/scripts/x.applescript");
+      expect(writtenScript()).toContain("-- template {{name}}");
+    });
+
+    it("honours an explicit timeout", async () => {
+      await runAppleScript("accounts/scripts/x.applescript", undefined, { timeout: 5_000 });
+      expect(mockExec).toHaveBeenCalledWith(
+        "osascript",
+        expect.any(Array),
+        expect.objectContaining({ timeout: 5_000 })
+      );
+    });
+
+    it("removes the temp directory afterwards", async () => {
+      await runAppleScript("accounts/scripts/x.applescript");
+      expect(mockRm).toHaveBeenCalledWith("/tmp/macos-mail-mcp-test", {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+
+  describe("stderr on a successful run", () => {
+    it("warns but still returns the parsed result", async () => {
+      const warn = vi.fn();
+      vi.stubGlobal("console", { ...console, warn });
+      mockExec.mockResolvedValue({ stdout: '{"ok": true}', stderr: "  some warning  " });
+
+      await expect(runAppleScript("accounts/scripts/x.applescript")).resolves.toEqual({
+        ok: true,
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("some warning"));
+    });
+
+    it("does not warn on whitespace-only stderr", async () => {
+      const warn = vi.fn();
+      vi.stubGlobal("console", { ...console, warn });
+      mockExec.mockResolvedValue({ stdout: '{"ok": true}', stderr: "   " });
+
+      await runAppleScript("accounts/scripts/x.applescript");
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("execution failures", () => {
+    it("reports a timeout in seconds when the process was killed", async () => {
+      mockExec.mockRejectedValue(Object.assign(new Error("killed"), { killed: true }));
+      await expect(
+        runAppleScript("accounts/scripts/x.applescript", undefined, { timeout: 45_000 })
+      ).rejects.toThrow("AppleScript timed out after 45 seconds");
+    });
+
+    it("translates a 'is not running' stderr into actionable guidance", async () => {
+      mockExec.mockRejectedValue(
+        Object.assign(new Error("boom"), { stderr: 'Application "Mail" is not running.' })
+      );
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow(
+        "Mail.app is not running. Please open it first."
+      );
+    });
+
+    it("surfaces stderr for any other failure", async () => {
+      mockExec.mockRejectedValue(
+        Object.assign(new Error("boom"), { stderr: "syntax error: expected end" })
+      );
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow(
+        "AppleScript execution failed: syntax error: expected end"
+      );
+    });
+
+    it("falls back to the error message when stderr is empty", async () => {
+      mockExec.mockRejectedValue(Object.assign(new Error("spawn ENOENT"), { stderr: "" }));
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow(
+        "AppleScript execution failed: spawn ENOENT"
+      );
+    });
+
+    it("falls back to the error message when there is no stderr at all", async () => {
+      mockExec.mockRejectedValue(new Error("spawn EACCES"));
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow(
+        "AppleScript execution failed: spawn EACCES"
+      );
+    });
+
+    it("still cleans up the temp directory when execution fails", async () => {
+      mockExec.mockRejectedValue(Object.assign(new Error("boom"), { stderr: "nope" }));
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow();
+      expect(mockRm).toHaveBeenCalledWith("/tmp/macos-mail-mcp-test", {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it("still cleans up when the output is not valid JSON", async () => {
+      mockExec.mockResolvedValue({ stdout: "not json", stderr: "" });
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow();
+      expect(mockRm).toHaveBeenCalled();
+    });
+
+    it("throws the AppleScript error shape returned by a script", async () => {
+      mockExec.mockResolvedValue({
+        stdout: '{"error": "no such mailbox", "errorNumber": -1728}',
+        stderr: "",
+      });
+      await expect(runAppleScript("accounts/scripts/x.applescript")).rejects.toThrow(
+        /no such mailbox/
+      );
+    });
+  });
+});

--- a/tests/domains/mailboxes/mailboxes.registration.test.ts
+++ b/tests/domains/mailboxes/mailboxes.registration.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/bridge/applescript-runner.js", () => ({
+  runAppleScript: vi.fn(),
+  EXTENDED_TIMEOUT: 120_000,
+  DEFAULT_TIMEOUT: 30_000,
+}));
+
+import { runAppleScript } from "../../../src/bridge/applescript-runner.js";
+import { registerMailboxesTools } from "../../../src/domains/mailboxes/mailboxes.tools.js";
+import { captureTools, payload, type RegisteredTool } from "../../helpers/capture-tools.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+describe("mailboxes tool registration", () => {
+  let tools: Map<string, RegisteredTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAppleScript.mockResolvedValue({ ok: true });
+    tools = captureTools(registerMailboxesTools);
+  });
+
+  it("registers all three mailbox tools", () => {
+    expect([...tools.keys()].sort()).toEqual([
+      "create_mailbox",
+      "get_mailbox_info",
+      "list_mailboxes",
+    ]);
+  });
+
+  describe("list_mailboxes", () => {
+    it("returns the result as JSON content", async () => {
+      const result = await tools.get("list_mailboxes")!.handler({ accountName: "Google" });
+      expect(payload(result)).toEqual({ ok: true });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("passes the requested account", async () => {
+      await tools.get("list_mailboxes")!.handler({ accountName: "Google" });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/list-mailboxes.applescript",
+        { accountName: "Google" }
+      );
+    });
+
+    it("uses the __ALL__ sentinel when no account is given", async () => {
+      await tools.get("list_mailboxes")!.handler({});
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/list-mailboxes.applescript",
+        { accountName: "__ALL__" }
+      );
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("Mail.app is not running"));
+      const result = await tools.get("list_mailboxes")!.handler({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Mail\.app is not running/);
+    });
+  });
+
+  describe("create_mailbox", () => {
+    it("creates a top-level mailbox with the __NONE__ parent sentinel", async () => {
+      await tools.get("create_mailbox")!.handler({
+        accountName: "Google",
+        mailboxName: "Archive",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/create-mailbox.applescript",
+        { accountName: "Google", mailboxName: "Archive", parentMailboxName: "__NONE__" }
+      );
+    });
+
+    it("passes a parent mailbox when nesting", async () => {
+      await tools.get("create_mailbox")!.handler({
+        accountName: "Google",
+        mailboxName: "2026",
+        parentMailboxName: "Archive",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/create-mailbox.applescript",
+        { accountName: "Google", mailboxName: "2026", parentMailboxName: "Archive" }
+      );
+    });
+
+    it("strips newlines from names", async () => {
+      await tools.get("create_mailbox")!.handler({
+        accountName: "Goo\ngle",
+        mailboxName: "Arch\nive",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/create-mailbox.applescript",
+        expect.objectContaining({ accountName: "Goo gle", mailboxName: "Arch ive" })
+      );
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("mailbox exists"));
+      const result = await tools.get("create_mailbox")!.handler({
+        accountName: "Google",
+        mailboxName: "Archive",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("get_mailbox_info", () => {
+    it("passes account and mailbox through", async () => {
+      await tools.get("get_mailbox_info")!.handler({
+        accountName: "Google",
+        mailboxName: "[Gmail]/All Mail",
+      });
+      expect(mockRunAppleScript).toHaveBeenCalledWith(
+        "mailboxes/scripts/get-mailbox-info.applescript",
+        { accountName: "Google", mailboxName: "[Gmail]/All Mail" }
+      );
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("no such mailbox"));
+      const result = await tools.get("get_mailbox_info")!.handler({
+        accountName: "Google",
+        mailboxName: "Nope",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/no such mailbox/);
+    });
+  });
+});

--- a/tests/domains/messages/messages.registration.test.ts
+++ b/tests/domains/messages/messages.registration.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/bridge/applescript-runner.js", () => ({
+  runAppleScript: vi.fn(),
+  EXTENDED_TIMEOUT: 120_000,
+  DEFAULT_TIMEOUT: 30_000,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdtemp: vi.fn().mockResolvedValue("/tmp/mail-mcp-att-abc123"),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runAppleScript } from "../../../src/bridge/applescript-runner.js";
+import { registerMessagesTools } from "../../../src/domains/messages/messages.tools.js";
+import { captureTools, payload, type RegisteredTool } from "../../helpers/capture-tools.js";
+
+const mockRunAppleScript = vi.mocked(runAppleScript);
+
+const ID = { messageId: 1, mailboxName: "INBOX", accountName: "Google" };
+
+const TOOLS = [
+  {
+    name: "list_messages",
+    args: { accountName: "Google", mailboxName: "INBOX", limit: 25, offset: 0 },
+    script: "messages/scripts/list-messages.applescript",
+  },
+  {
+    name: "get_message",
+    args: { messageId: 1, accountName: "Google", mailboxName: "INBOX" },
+    script: "messages/scripts/get-message.applescript",
+  },
+  {
+    name: "search_messages",
+    args: { field: "subject", query: "invoice", limit: 50 },
+    script: "messages/scripts/search-messages.applescript",
+  },
+  {
+    name: "move_message",
+    args: { ...ID, toMailbox: "Archive" },
+    script: "messages/scripts/move-message.applescript",
+  },
+  {
+    name: "move_messages",
+    args: {
+      accountName: "Google",
+      mailboxName: "INBOX",
+      messageIds: [1, 2],
+      toMailbox: "Archive",
+    },
+    script: "messages/scripts/move-messages.applescript",
+  },
+  {
+    name: "delete_message",
+    args: ID,
+    script: "messages/scripts/delete-message.applescript",
+  },
+  {
+    name: "flag_message",
+    args: { ...ID, flagged: true, flagIndex: -1 },
+    script: "messages/scripts/flag-message.applescript",
+  },
+  {
+    name: "mark_read",
+    args: { ...ID, read: true },
+    script: "messages/scripts/mark-read.applescript",
+  },
+  {
+    name: "list_attachments",
+    args: ID,
+    script: "messages/scripts/list-attachments.applescript",
+  },
+  {
+    name: "save_attachment",
+    args: { ...ID, attachmentName: "a.pdf", savePath: "~/Downloads" },
+    script: "messages/scripts/save-attachment.applescript",
+  },
+  {
+    name: "save_all_attachments",
+    args: { ...ID, savePath: "~/Downloads" },
+    script: "messages/scripts/save-all-attachments.applescript",
+  },
+  {
+    name: "read_attachment",
+    args: { ...ID, attachmentName: "a.txt" },
+    script: "messages/scripts/read-attachment.applescript",
+  },
+] as const;
+
+describe("messages tool registration", () => {
+  let tools: Map<string, RegisteredTool>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAppleScript.mockResolvedValue({ ok: true });
+    tools = captureTools(registerMessagesTools);
+  });
+
+  it("registers all twelve message and attachment tools", () => {
+    expect([...tools.keys()].sort()).toEqual([...TOOLS.map((t) => t.name)].sort());
+  });
+
+  describe.each(TOOLS)("$name", ({ name, args, script }) => {
+    it("returns the handler result as JSON content", async () => {
+      const result = await tools.get(name)!.handler({ ...args });
+      expect(payload(result)).toEqual({ ok: true });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("invokes its AppleScript template", async () => {
+      await tools.get(name)!.handler({ ...args });
+      // Arity varies — the slower tools pass a third timeout argument.
+      expect(mockRunAppleScript.mock.calls.map((call) => call[0])).toContain(script);
+    });
+
+    it("surfaces a failure as an MCP error", async () => {
+      mockRunAppleScript.mockRejectedValue(new Error("Mail.app is not running"));
+      const result = await tools.get(name)!.handler({ ...args });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Mail\.app is not running/);
+    });
+
+    it("has a non-empty description", () => {
+      expect(tools.get(name)!.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("get_message without a mailboxName", () => {
+    it("falls back to the by-id lookup script", async () => {
+      await tools.get("get_message")!.handler({ messageId: 1, accountName: "Google" });
+      expect(mockRunAppleScript.mock.calls.map((call) => call[0])).toContain(
+        "messages/scripts/get-message-by-id.applescript"
+      );
+    });
+  });
+
+  describe("read_attachment extension handling", () => {
+    it("refuses a binary extension", async () => {
+      const result = await tools.get("read_attachment")!.handler({
+        ...ID,
+        attachmentName: "photo.png",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Binary file type not supported/);
+    });
+
+    it("refuses a name with no extension at all", async () => {
+      const result = await tools.get("read_attachment")!.handler({
+        ...ID,
+        attachmentName: "README",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Binary file type not supported/);
+    });
+  });
+
+  describe("search_messages optional scoping", () => {
+    it("accepts a search with neither mailbox nor account", async () => {
+      const result = await tools.get("search_messages")!.handler({
+        field: "sender",
+        query: "bob@test.com",
+        limit: 10,
+      });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("defaults the limit when none is supplied", async () => {
+      await tools.get("search_messages")!.handler({ field: "subject", query: "x" });
+      const params = mockRunAppleScript.mock.calls.find(([s]) =>
+        String(s).includes("search-messages")
+      )?.[1] as Record<string, string>;
+      expect(params.limit).toBe("50");
+    });
+
+    it("rejects an unparseable date filter", async () => {
+      const result = await tools.get("search_messages")!.handler({
+        field: "subject",
+        query: "x",
+        limit: 10,
+        after: "not-a-date",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toMatch(/Invalid date: not-a-date/);
+    });
+
+    it("accepts date-filter-only searches", async () => {
+      const result = await tools.get("search_messages")!.handler({
+        field: "subject",
+        query: "",
+        limit: 10,
+        after: "2026-01-01T00:00:00Z",
+      });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+});

--- a/tests/helpers/capture-tools.ts
+++ b/tests/helpers/capture-tools.ts
@@ -1,0 +1,39 @@
+// Test helper: drive the real registerXxxTools() functions without a live MCP server.
+export interface ToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: true;
+}
+
+export interface RegisteredTool {
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<ToolResult>;
+}
+
+/**
+ * Run a domain's registration function against a stub server and return what it
+ * registered, so the tool handlers themselves — not just the underlying
+ * handleXxx functions — can be exercised.
+ */
+export function captureTools(
+  register: (server: never) => void
+): Map<string, RegisteredTool> {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool: (
+      name: string,
+      description: string,
+      schema: Record<string, unknown>,
+      handler: RegisteredTool["handler"]
+    ) => {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  register(server as never);
+  return tools;
+}
+
+/** Parse the JSON payload an MCP tool handler returns. */
+export function payload(result: ToolResult): unknown {
+  return JSON.parse(result.content[0]!.text);
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const connect = vi.fn<() => Promise<void>>();
+const McpServer = vi.fn();
+const StdioServerTransport = vi.fn();
+
+const registerAccountsTools = vi.fn();
+const registerMailboxesTools = vi.fn();
+const registerMessagesTools = vi.fn();
+const registerComposeTools = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: class {
+    connect = connect;
+    constructor(options: unknown) {
+      McpServer(options);
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: class {
+    constructor() {
+      StdioServerTransport();
+    }
+  },
+}));
+
+vi.mock("../src/domains/accounts/accounts.tools.js", () => ({ registerAccountsTools }));
+vi.mock("../src/domains/mailboxes/mailboxes.tools.js", () => ({ registerMailboxesTools }));
+vi.mock("../src/domains/messages/messages.tools.js", () => ({ registerMessagesTools }));
+vi.mock("../src/domains/compose/compose.tools.js", () => ({ registerComposeTools }));
+
+const { version } = JSON.parse(
+  readFileSync(join(process.cwd(), "package.json"), "utf8")
+) as { version: string };
+
+/** Import the entry point fresh — it wires everything up as a side effect. */
+async function loadEntryPoint(): Promise<void> {
+  vi.resetModules();
+  await import("../src/index.js");
+  // main() is not awaited by the module itself; let its microtasks settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("entry point", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connect.mockResolvedValue(undefined);
+    vi.stubGlobal("console", { ...console, error: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("names the server and reports the version from package.json", async () => {
+    await loadEntryPoint();
+    expect(McpServer).toHaveBeenCalledWith({ name: "macos-mail-mcp", version });
+  });
+
+  it("does not hardcode a version that could drift from the package", async () => {
+    await loadEntryPoint();
+    const options = McpServer.mock.calls[0]![0] as { version: string };
+    expect(options.version).toBe(version);
+    expect(options.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("registers all four tool domains", async () => {
+    await loadEntryPoint();
+    expect(registerAccountsTools).toHaveBeenCalledTimes(1);
+    expect(registerMailboxesTools).toHaveBeenCalledTimes(1);
+    expect(registerMessagesTools).toHaveBeenCalledTimes(1);
+    expect(registerComposeTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers every domain against the same server instance", async () => {
+    await loadEntryPoint();
+    const server = registerAccountsTools.mock.calls[0]![0];
+    expect(registerMailboxesTools).toHaveBeenCalledWith(server);
+    expect(registerMessagesTools).toHaveBeenCalledWith(server);
+    expect(registerComposeTools).toHaveBeenCalledWith(server);
+  });
+
+  it("connects over stdio", async () => {
+    await loadEntryPoint();
+    expect(StdioServerTransport).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces itself on stderr, keeping stdout free for the protocol", async () => {
+    await loadEntryPoint();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`macos-mail-mcp v${version} running on stdio`)
+    );
+  });
+
+  describe("when the transport fails to connect", () => {
+    it("logs the error and exits non-zero", async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as never);
+      connect.mockRejectedValue(new Error("stdio unavailable"));
+
+      await loadEntryPoint();
+
+      expect(console.error).toHaveBeenCalledWith("Fatal error:", expect.any(Error));
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       reporter: ["text", "html"],
+      // The suite covers src/ fully. Thresholds keep it that way: new code
+      // without tests fails the run rather than quietly lowering the number.
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
     },
   },
 });


### PR DESCRIPTION
Follow-up to #5, as requested. Stacked on `feat/sender-account-selection` so it inherits the coverage tooling — **merge #5 first**, then this retargets to `main` automatically.

## Result

| | Before | After |
|---|---|---|
| Tests | 74 | 280 |
| Statements | 56.65% | **100%** |
| Branches | 81% | **100%** |
| Functions | 67.18% | **100%** |
| Lines | 56.87% | **100%** |

`accounts.tools.ts` was already brought to 100% in #5 — `handleListAccounts` became load-bearing for sender resolution there, so it was covered as part of that change rather than deferred to here.

## What was actually missing

The gaps were structural, not incidental. The suite called the `handleXxx` functions directly and never went through the tool handlers registered on the MCP server, so **every domain's registration layer was untested** — including all the `catch` blocks that turn a thrown error into an `isError` result. The `osascript` execution path in the bridge and the entry point had no tests at all.

- `tests/helpers/capture-tools.ts` — drives the real `registerXxxTools()` functions against a stub server, so handlers are exercised the way an MCP client calls them. Used by the mailboxes and messages suites.
- **Bridge** — `runAppleScript` end to end with `execFile` mocked through its `promisify.custom` hook (a plain `vi.fn()` loses the `{stdout, stderr}` shape): param substitution, shared-handler prepending and ordering, the timeout option, temp-dir cleanup on both success *and* failure, the killed-process timeout message, the "Mail is not running" translation, stderr-on-success warnings, and malformed output.
- **Entry point** — all four domains register against one server instance, the version comes from `package.json` rather than a literal, the banner goes to stderr so stdout stays free for the protocol, and a failed `connect` logs and exits 1.
- Remaining branch gaps: invalid date filters, an omitted search limit, and attachment names with no extension.

## Not just a number

Coverage thresholds are set to 100% in `vitest.config.ts` and CI now runs `test:coverage` instead of `test`, so untested new code fails the build rather than quietly lowering the percentage. Verified the gate actually bites — an impossible threshold exits 1, the real ones exit 0. Thresholds that aren't enforced in CI are decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)