### PR TITLE
chore: raise minimum Node.js from 18 to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Minimum Node.js raised from 18 to 20.** Node 18 reached end of life and was never actually
+  verified — CI builds and tests on 20, 22 and 24, so the `>=18` floor was an untested claim, and
+  the current toolchain (TypeScript 7) is unlikely to support it. Installing on Node 18 now warns
+  via `EBADENGINE` instead of appearing supported.
 - `accountName` on `reply_to_message` / `forward_message` is documented as locating the source
   message only. It never controlled which account sends, and the name invited the opposite
   assumption; `fromAccount` is the sender selector.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Works with **any email account configured in Mail.app** — iCloud, Gmail, Outlo
 
 ## Tech Stack
 
+- **Runtime:** Node.js 20+ (`engines` floor; CI builds and tests on 20, 22 and 24)
 - **Language:** TypeScript (ES2022, Node16 module resolution)
 - **MCP SDK:** `@modelcontextprotocol/sdk` v1.x (stdio transport)
 - **Mail integration:** AppleScript via `osascript` (execFile, not exec — prevents shell injection)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ npm run build
 npm test
 ```
 
-**Requirements:** macOS with Mail.app, Node.js 18+.
+**Requirements:** macOS with Mail.app, Node.js 20+.
 
 ## Project Structure
 
@@ -45,8 +45,8 @@ tests/                               # Vitest unit tests (mocked bridge)
    - Call `sanitize()` on all string params before passing to `runAppleScript`
    - Use `EXTENDED_TIMEOUT` for potentially slow operations
 4. **Register the tool** with `server.tool(name, description, zodSchema, handler)`
-5. **Add tests** in `tests/domains/<domain>/`
-6. **Verify:** `npm run build && npm test`
+5. **Add tests** in `tests/domains/<domain>/` — cover the registered tool handler, not just the handler function
+6. **Verify:** `npm run build && npm run test:coverage`
 
 ## How to Add a New Domain
 
@@ -66,17 +66,29 @@ tests/                               # Vitest unit tests (mocked bridge)
 
 ```bash
 npm test              # Run all tests
+npm run test:coverage # Tests + coverage, enforcing the thresholds CI uses
 npm run test:watch    # Watch mode
 ```
 
 Tests mock the AppleScript bridge, so they don't require Mail.app or real email accounts.
+
+**Coverage is gated at 100%** — statements, branches, functions and lines — in
+`vitest.config.ts`, and CI runs `test:coverage` rather than `test`. Adding code
+without covering it fails the build, so run `npm run test:coverage` before
+opening a PR rather than finding out in CI.
+
+Cover the tool handler, not only the `handleXxx` function beneath it. Registering
+a tool adds a `catch` block that turns a thrown error into an MCP `isError`
+result; that path is only reached by invoking the registered handler. Use
+`captureTools()` from `tests/helpers/capture-tools.ts`, which runs the real
+`registerXxxTools()` against a stub server.
 
 ## Submitting Changes
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-new-tool`)
 3. Make your changes
-4. Run `npm run build && npm test` to verify
+4. Run `npm run build && npm run test:coverage` to verify
 5. Commit with a descriptive message
 6. Open a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/macos-mail-mcp.svg)](https://www.npmjs.com/package/macos-mail-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js 18+](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org/)
+[![Node.js 20+](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 [![macOS](https://img.shields.io/badge/platform-macOS-blue.svg)](https://www.apple.com/macos/)
 
 An MCP server for Apple Mail (macOS Mail.app) that connects Claude to your email via AppleScript. Provides 20 tools for reading, searching, managing, and composing emails.
@@ -14,7 +14,7 @@ Works with **any email account configured in macOS Mail.app** — iCloud, Gmail,
 ## Requirements
 
 - macOS with Mail.app configured (with at least one email account)
-- Node.js 18+
+- Node.js 20+
 - Claude Code or Claude Desktop app
 
 ## Installation
@@ -197,9 +197,11 @@ src/
       sender.ts                     # Resolves fromAccount to a "Name <address>" sender
       scripts/*.applescript
 tests/
+  index.test.ts                     # Entry point: wiring, version, stdio
   utils.test.ts                     # Shared utility tests
-  bridge/applescript-runner.test.ts  # Bridge unit tests
-  domains/*/                         # Domain handler tests
+  helpers/capture-tools.ts          # Stub server for exercising registered tools
+  bridge/                           # Escaping/parsing + runAppleScript execution
+  domains/*/                        # Handler and registration-layer tests
 ```
 
 **Domain-driven layered architecture:**
@@ -240,11 +242,16 @@ Mail.app's internal message IDs are volatile — they can change when the app re
 ## Development
 
 ```bash
-npm run dev          # Watch mode (TypeScript compiler)
-npm test             # Run tests
-npm run test:watch   # Watch mode tests
-npm run build        # Build for production
+npm run dev           # Watch mode (TypeScript compiler)
+npm test              # Run tests
+npm run test:coverage # Tests + coverage report
+npm run test:watch    # Watch mode tests
+npm run build         # Build for production
 ```
+
+The suite covers `src/` fully, and `vitest.config.ts` enforces 100% statement,
+branch, function and line thresholds. CI runs `test:coverage`, so new code
+without tests fails the build.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "model-context-protocol"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "bin": {
     "macos-mail-mcp": "build/index.js"


### PR DESCRIPTION
The `engines` floor claimed Node 18, but nothing verified it — CI builds and tests on 20, 22 and 24 only. Node 18 is EOL and TypeScript 7 is unlikely to support it, so `>=18` was an untested claim in both directions. Corrected to match what's actually exercised; Node 18 installs now warn via `EBADENGINE` instead of appearing supported.

Updated everywhere the floor was stated, not just `package.json`: the README badge, the README requirements list, and CONTRIBUTING.

## Docs brought up to date

The coverage work landed a gate that wasn't documented anywhere — a contributor adding code without tests would hit a CI failure with no warning in any doc:

- README and CONTRIBUTING now document `npm run test:coverage` and the 100% threshold.
- CONTRIBUTING explains covering the *registered tool handler*, not only the `handleXxx` function beneath it, and points at `captureTools()`. The registration `catch` blocks that produce MCP `isError` results are unreachable any other way — that was the single biggest coverage gap before #20.
- README's test tree reflects the entry-point, bridge-execution and helper files.
- CLAUDE.md states the runtime floor and CI matrix.

Verified locally: build clean, 280 tests, 100% across statements/branches/functions/lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)