### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+# Publishes to npm when a v* tag is pushed.
+#
+# Authentication uses npm Trusted Publishing (OIDC) — there is no NPM_TOKEN in
+# this repository, and no long-lived credential to leak. npm verifies the
+# workflow identity directly, which also produces a provenance attestation.
+#
+# One-time setup on npmjs.com → the package → Settings → Trusted Publisher:
+#   Provider:   GitHub Actions
+#   Repository: marius-cetanas/macos-mail-mcp
+#   Workflow:   release.yml
+# Renaming or moving this file breaks publishing until that entry is updated.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for Trusted Publishing and provenance. Nothing else needs write.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      # Trusted Publishing needs npm >= 11.5.1. Node 24 ships a recent npm, but
+      # pinning the floor here keeps the job honest if the runner image changes.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - run: npm ci
+
+      - name: Verify the tag matches package.json
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME implies version $TAG but package.json says $PKG."
+            echo "Refusing to publish a mismatched version."
+            exit 1
+          fi
+          echo "Publishing version $PKG."
+
+      # Re-verify rather than trusting that the tagged commit passed CI on a PR.
+      - run: npm run build
+      - run: npm run test:coverage
+      - run: npm audit --audit-level=high
+
+      - name: Publish
+        run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-08-04
 
 ### Added
 
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `handleXxx` functions beneath them — had never been exercised, nor had the `osascript` execution
   path in the bridge or the entry point. Coverage thresholds are set to 100% and CI runs
   `test:coverage`, so untested new code fails the build instead of quietly lowering the number.
+- CI, CodeQL and Dependabot added; `main` is branch-protected behind a required check. Actions are
+  pinned to commit SHAs and workflows run with a read-only token. Releases publish from a tag via
+  npm Trusted Publishing (OIDC), so no npm token is stored in the repository.
+- Dependency updates: zod 3 → 4, TypeScript 6 → 7, `@types/node` 25 → 26, plus transitive fixes
+  clearing several high-severity advisories in the MCP SDK's HTTP stack. `npm audit` reports 0
+  vulnerabilities, and `audit` is part of the required CI gate.
 
 ### Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macos-mail-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macos-mail-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-mail-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP server connecting Claude to macOS Mail.app via AppleScript",
   "type": "module",
   "author": "Marius Cetanas",


### PR DESCRIPTION
Cuts 1.3.0 and adds the release automation.

## Version choice

**1.3.0, not 2.0.0.** `fromAccount` is optional and the MCP tool surface stays backward compatible — no existing call breaks. The Node floor moving to 20 is the only thing arguing for a major, and it surfaces as an `EBADENGINE` warning on a runtime that is already end of life.

## Release workflow

Publishes on a `v*` tag via **npm Trusted Publishing (OIDC)**. There is no `NPM_TOKEN` in this repo — npm verifies the workflow identity directly, so there is no long-lived credential to leak, and the publish carries a provenance attestation automatically.

The job deliberately re-runs `build`, `test:coverage` and `audit` before publishing rather than trusting that the tagged commit was green on a PR, and **refuses to publish when the tag and `package.json` disagree** — verified both branches of that guard locally (`v1.3.0` → publish, `v1.2.9` → refuse).

## One-time setup needed before the tag will publish

On npmjs.com → `macos-mail-mcp` → Settings → Trusted Publisher:

| Field | Value |
|---|---|
| Provider | GitHub Actions |
| Repository | `marius-cetanas/macos-mail-mcp` |
| Workflow | `release.yml` |

Renaming or moving that workflow file breaks publishing until the entry is updated — noted in a comment at the top of the file.

## Verified locally

Build clean, 280 tests, 100% coverage, 0 vulnerabilities. `npm pack --dry-run` produces `macos-mail-mcp@1.3.0` containing the compiled `sender.js`, all three updated compose templates, and the `fromAccount` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)