### PR TITLE
fix(release): stop setup-node's empty _authToken from disabling OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # Lets the publish path be validated without minting a tag. A tag is a
+  # permanent, public artifact; discovering a broken pipeline by pushing one and
+  # watching it fail is how v1.3.0 ended up tagged but unpublished.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run every check and stop before publishing"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -33,11 +42,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # Deliberately no `registry-url` and no `cache`.
+      #
+      # registry-url makes setup-node write `_authToken=${NODE_AUTH_TOKEN}` into
+      # a generated .npmrc. With no NODE_AUTH_TOKEN the placeholder expands to
+      # empty — but an empty token is still a token, so npm treats auth as
+      # already configured, never starts the OIDC exchange, and publishes
+      # anonymously (E404). See actions/setup-node#1551. The default registry is
+      # registry.npmjs.org anyway, so the setting bought nothing.
+      #
+      # npm's own guidance is not to cache in release builds.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-          cache: npm
 
       # Trusted Publishing needs npm >= 11.5.1. Node 24 ships a recent npm, but
       # pinning the floor here keeps the job honest if the runner image changes.
@@ -46,23 +63,96 @@ jobs:
           npm install -g npm@latest
           npm --version
 
+      # Fails loudly on the misconfigurations that otherwise surface as a bare
+      # E404 from an anonymous publish, which reads like "package not found"
+      # and sends you looking in the wrong place entirely.
+      - name: Preflight — OIDC can actually be used
+        run: |
+          fail=0
+
+          # id-token: write is what makes this variable exist. No variable, no
+          # OIDC, regardless of what the permissions block claims.
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::No OIDC token endpoint. The job is missing 'id-token: write'."
+            fail=1
+          else
+            echo "OIDC token endpoint present."
+          fi
+
+          # Any _authToken npm can see — even an empty one — stops it starting
+          # the OIDC exchange. This is what broke the v1.3.0 release.
+          for f in "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" ./.npmrc; do
+            if [ -f "$f" ] && grep -q "_authToken" "$f"; then
+              echo "::error::$f sets _authToken; npm will skip OIDC and publish anonymously."
+              echo "Remove registry-url from actions/setup-node. See actions/setup-node#1551."
+              fail=1
+            fi
+          done
+          if [ "$fail" -eq 0 ]; then echo "No conflicting _authToken found."; fi
+
+          node -e '
+            const [maj, min, pat] = process.versions.node.split(".").map(Number);
+            const ok = maj > 22 || (maj === 22 && (min > 14 || (min === 14 && pat >= 0)));
+            if (!ok) { console.error(`::error::Node ${process.versions.node} < 22.14.0, required for trusted publishing.`); process.exit(1); }
+            console.log(`Node ${process.versions.node} meets the 22.14.0 floor.`);
+          ' || fail=1
+
+          exit $fail
+
       - run: npm ci
 
       - name: Verify the tag matches package.json
+        if: github.ref_type == 'tag'
         run: |
           TAG="${GITHUB_REF_NAME#v}"
           PKG="$(node -p "require('./package.json').version")"
           if [ "$TAG" != "$PKG" ]; then
-            echo "Tag $GITHUB_REF_NAME implies version $TAG but package.json says $PKG."
-            echo "Refusing to publish a mismatched version."
+            echo "::error::Tag $GITHUB_REF_NAME implies version $TAG but package.json says $PKG."
             exit 1
           fi
           echo "Publishing version $PKG."
+
+      # A tag naming a version that is already on the registry cannot publish —
+      # npm rejects republishing. Better to say so than to fail at the last step.
+      - name: Verify the version is not already published
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          if npm view "macos-mail-mcp@$PKG" version >/dev/null 2>&1; then
+            echo "::error::macos-mail-mcp@$PKG is already on the registry. Bump the version."
+            exit 1
+          fi
+          echo "$PKG is not yet published."
 
       # Re-verify rather than trusting that the tagged commit passed CI on a PR.
       - run: npm run build
       - run: npm run test:coverage
       - run: npm audit --audit-level=high
 
+      - name: Publish (dry run)
+        if: inputs.dry_run
+        run: |
+          npm publish --dry-run
+          echo "Dry run only — nothing was published."
+          echo "Everything up to the registry handshake is verified; the handshake"
+          echo "itself is only exercised by a real publish."
+
       - name: Publish
+        if: ${{ !inputs.dry_run }}
         run: npm publish
+
+      - name: Confirm it landed
+        if: ${{ !inputs.dry_run }}
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          for i in $(seq 1 10); do
+            sleep 6
+            if npm view "macos-mail-mcp@$PKG" version >/dev/null 2>&1; then
+              echo "Published: macos-mail-mcp@$PKG"
+              npm view "macos-mail-mcp@$PKG" dist.attestations >/dev/null 2>&1 \
+                && echo "Provenance attestation present." \
+                || echo "::warning::No provenance attestation — publish did not go through OIDC."
+              exit 0
+            fi
+          done
+          echo "::error::$PKG is not on the registry after publishing appeared to succeed."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,34 @@ npm run test:watch   # Watch mode
 npm run dev          # TypeScript watch mode
 ```
 
+## Releasing
+
+Pushing a `v*` tag runs `.github/workflows/release.yml`, which publishes to npm via
+Trusted Publishing (OIDC). There is no `NPM_TOKEN` in the repo.
+
+Before the first tag-triggered publish can work, npmjs.com → the package → Settings →
+Trusted Publisher must name the org/user, the repo, the workflow **filename**
+(`release.yml`) and allow the `npm publish` action. Renaming that file breaks publishing
+until the entry is updated.
+
+Validate the pipeline without minting a tag by running the workflow manually with
+`dry_run` (the default). A tag is permanent and public; a failed tag-triggered publish
+leaves a tag pointing at an unpublished version.
+
+Order for a release: land the version bump and changelog on `main`, run a dry run, then
+tag. Never tag first.
+
+**Do not add `registry-url` to `actions/setup-node` in this workflow.** It writes
+`_authToken=${NODE_AUTH_TOKEN}` into a generated `.npmrc`; with no token set that expands
+to empty, and an empty token still reads as configured auth, so npm skips the OIDC
+exchange and publishes anonymously. The symptom is a bare `E404` from `PUT`, which looks
+like a missing package rather than an auth failure. This cost the v1.3.0 release
+(actions/setup-node#1551). A preflight step now fails the job if any `_authToken` is
+visible, so the mistake cannot silently recur.
+
+Provenance attestations are attached at publish time and cannot be added afterwards. A
+version published outside OIDC has none, permanently.
+
 ## Registration
 
 **Claude Code CLI:**


### PR DESCRIPTION
Fixes the root cause of the v1.3.0 publish failure. **My earlier diagnosis was wrong** — I said it was the missing trusted-publisher registration; the logs actually pointed at the workflow I wrote.

## What happened

The tag run passed every check, then failed on `npm publish` with a bare `E404` on `PUT`. That reads like "package not found", which sends you looking at the registry. But the logs showed npm 12.0.2, `id-token: write` granted, and **no OIDC activity at all** — npm never attempted the exchange. A missing registration would have shown an attempt and a rejection.

The cause is `registry-url` on `actions/setup-node`. It unconditionally writes `_authToken=\${NODE_AUTH_TOKEN}` into a generated `.npmrc`. With no token set, that expands to empty — and **an empty token still reads as configured auth**, so npm skips OIDC and publishes anonymously. npm answers an anonymous publish with 404 rather than 401 so it doesn't leak whether a package exists, which is what made this misleading ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551)).

Removed `registry-url` — `registry.npmjs.org` is the default, so it bought nothing — and `cache`, which npm advises against in release builds.

## Guards so it can't recur silently

- **Preflight** fails the job if any visible `.npmrc` sets `_authToken`, if the OIDC token endpoint is missing (i.e. `id-token: write` isn't really in effect), or if Node is below the 22.14.0 floor.
- **Already-published check** runs before the build — npm won't republish a version, so failing at the last step wastes the run.
- **Post-publish confirmation** verifies the version actually appears on the registry, and warns when there's no provenance attestation — the tell that a publish didn't go through OIDC.

## No more tagging to find out

Adds `workflow_dispatch` with a `dry_run` input defaulting to true, so the pipeline can be exercised without minting a tag. Tags are permanent and public; the last failure left `v1.3.0` tagged but unpublished for a day.

Release order is now documented in CLAUDE.md: land the bump, dry run, *then* tag.

## Still needed before a tag will publish

The trusted-publisher registration on npmjs.com is genuinely still required — it just wasn't what the logs were showing. Provider `GitHub Actions`, this repo, workflow filename `release.yml`, action `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)