### PR TITLE
docs: register via npx, not a frozen local build path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,9 +209,13 @@ published outside OIDC has none, permanently; 1.3.0 is such a version.
 
 ## Registration
 
+Register via `npx`, not a local build path. `npx` re-resolves the published version
+at every server start, so an installed copy picks up each release on its own; a path
+into `build/` is frozen at whatever was last compiled there.
+
 **Claude Code CLI:**
 ```bash
-claude mcp add --transport stdio --scope user macos-mail-mcp -- node /path/to/macos-mail-mcp/build/index.js
+claude mcp add --transport stdio --scope user macos-mail-mcp -- npx -y macos-mail-mcp@latest
 ```
 
 **Claude Desktop:** Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
@@ -219,9 +223,40 @@ claude mcp add --transport stdio --scope user macos-mail-mcp -- node /path/to/ma
 {
   "mcpServers": {
     "macos-mail-mcp": {
-      "command": "node",
-      "args": ["/path/to/macos-mail-mcp/build/index.js"]
+      "command": "/opt/homebrew/bin/npx",
+      "args": ["-y", "macos-mail-mcp@latest"],
+      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" }
     }
   }
 }
 ```
+
+Use the absolute path to `npx` for Claude Desktop — GUI apps do not inherit the shell
+`PATH`, so a bare `"npx"` usually fails to launch.
+
+`@latest` is belt and braces rather than a fix. A bare package name already re-resolves
+from the registry today: for a name with no version, npm skips the range-satisfies
+shortcut and fetches the manifest with `preferOnline`, so the `"^1.3.0"` written into the
+npx cache records the last install rather than pinning it. `@latest` takes the tag branch
+instead, which re-resolves independently of that heuristic — so if npm ever changes it,
+the bare form would freeze on an old version silently, with no signal. The cost is one
+extra download, since the two forms hash to different cache keys.
+
+Two consequences of resolving at start-up, both real:
+
+- **An update only lands when the server process starts.** A long-running Claude Desktop
+  keeps serving the version it launched with, however new the one on disk is. Restarting
+  the app is what puts a new release live.
+- **The check is a registry round-trip**, so with the registry unreachable the server
+  fails to start at all rather than falling back to the cached copy. That is the trade-off
+  of always-current; do not "fix" it by pinning a version.
+
+**For development on this server**, register the local build instead — that is the point
+of it, since you want the code in your working tree rather than the published release:
+
+```bash
+claude mcp add --transport stdio --scope user macos-mail-mcp-dev -- node /path/to/macos-mail-mcp/build/index.js
+```
+
+Register it under a different name so it does not shadow the published copy, and
+remember it serves whatever `npm run build` last produced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,16 +223,20 @@ claude mcp add --transport stdio --scope user macos-mail-mcp -- npx -y macos-mai
 {
   "mcpServers": {
     "macos-mail-mcp": {
-      "command": "/opt/homebrew/bin/npx",
+      "command": "/absolute/path/to/npx",
       "args": ["-y", "macos-mail-mcp@latest"],
-      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" }
+      "env": { "PATH": "/absolute/path/to/node/bin:/usr/bin:/bin" }
     }
   }
 }
 ```
 
-Use the absolute path to `npx` for Claude Desktop — GUI apps do not inherit the shell
-`PATH`, so a bare `"npx"` usually fails to launch.
+Both paths are placeholders on purpose. Claude Desktop needs the **absolute** path to
+`npx` because GUI apps do not inherit the shell `PATH`, so a bare `"npx"` usually fails
+to launch — and the right absolute path differs per install: `/opt/homebrew/bin/npx` on
+Apple Silicon Homebrew, `/usr/local/bin/npx` on Intel, somewhere under `~/.nvm/versions`
+with nvm. Find yours with `which npx`. The `env.PATH` entry exists so `npx` can then
+locate `node`, for the same reason.
 
 `@latest` is belt and braces rather than a fix. A bare package name already re-resolves
 from the registry today: for a name with no version, npm skips the range-satisfies

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The easiest way — no cloning or building required.
 **Claude Code (CLI):**
 
 ```bash
-claude mcp add --scope user macos-mail-mcp -- npx -y macos-mail-mcp
+claude mcp add --scope user macos-mail-mcp -- npx -y macos-mail-mcp@latest
 ```
 
-`--scope user` makes the server available in every project — the default `local` scope only registers it for the directory you run the command in. `-y` lets `npx` install the package on first run without an interactive prompt.
+`--scope user` makes the server available in every project — the default `local` scope only registers it for the directory you run the command in. `-y` lets `npx` install the package on first run without an interactive prompt. `@latest` makes the auto-update behaviour explicit — see [Staying up to date](#staying-up-to-date).
 
 **Claude Desktop (and Cowork):**
 
@@ -42,7 +42,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "macos-mail-mcp": {
       "command": "/opt/homebrew/bin/npx",
-      "args": ["-y", "macos-mail-mcp"],
+      "args": ["-y", "macos-mail-mcp@latest"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" }
     }
   }
@@ -57,9 +57,32 @@ Use the **absolute path** to `npx` — GUI apps don't inherit your shell's `PATH
 
 The `env.PATH` entry lets `npx` locate `node` for the same reason. Then **fully quit** Claude (Cmd+Q — closing the window isn't enough) and reopen; the config is only read at startup. If the server doesn't appear, check `~/Library/Logs/Claude/mcp*.log` for spawn errors.
 
+### Staying up to date
+
+Installed copies update themselves. `npx` re-resolves the published version every time
+the server starts, so a new release is picked up without you touching the config.
+
+`@latest` in the commands above makes that explicit rather than changing it. A bare
+package name already re-resolves today: npm skips the range-satisfies shortcut for a name
+with no version and fetches the manifest with `preferOnline`, so the `"^1.3.0"` that
+appears in the npx cache records the last install rather than pinning it. `@latest` takes
+the tag branch instead, which does not depend on that heuristic — so if npm ever changes
+it, the bare form would freeze on an old version silently. The cost is one extra download,
+because the two forms hash to different cache keys.
+
+Two consequences worth knowing:
+
+- **Updates land at server start, not while it is running.** A long-running Claude Desktop
+  keeps serving the version it launched with. Quit and reopen it to pick up a release.
+- **The check is a registry round-trip.** With the registry unreachable the server fails to
+  start rather than falling back to the cached copy. That is the price of always-current;
+  pinning a version to avoid it gives up the updates.
+
 ### Install from Source
 
-If you prefer to build locally or want to contribute:
+For working on the server itself. This path does **not** auto-update — it runs whatever
+`npm run build` last produced in your working tree, which is exactly what you want while
+developing and not what you want otherwise.
 
 ```bash
 git clone https://github.com/marius-cetanas/macos-mail-mcp.git
@@ -68,10 +91,11 @@ npm install
 npm run build
 ```
 
-Then register with Claude Code:
+Then register with Claude Code. Use a distinct name so the local build does not shadow a
+published copy you may also have registered:
 
 ```bash
-claude mcp add --transport stdio --scope user macos-mail-mcp -- node /path/to/macos-mail-mcp/build/index.js
+claude mcp add --transport stdio --scope user macos-mail-mcp-dev -- node /path/to/macos-mail-mcp/build/index.js
 ```
 
 Or add to Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
@@ -79,7 +103,7 @@ Or add to Claude Desktop config (`~/Library/Application Support/Claude/claude_de
 ```json
 {
   "mcpServers": {
-    "macos-mail-mcp": {
+    "macos-mail-mcp-dev": {
       "command": "/opt/homebrew/bin/node",
       "args": ["/path/to/macos-mail-mcp/build/index.js"]
     }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The easiest way — no cloning or building required.
 **Claude Code (CLI):**
 
 ```bash
-claude mcp add --scope user macos-mail-mcp -- npx -y macos-mail-mcp@latest
+claude mcp add --transport stdio --scope user macos-mail-mcp -- npx -y macos-mail-mcp@latest
 ```
 
 `--scope user` makes the server available in every project — the default `local` scope only registers it for the directory you run the command in. `-y` lets `npx` install the package on first run without an interactive prompt. `@latest` makes the auto-update behaviour explicit — see [Staying up to date](#staying-up-to-date).

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "macos-mail-mcp": {
-      "command": "/opt/homebrew/bin/npx",
+      "command": "/absolute/path/to/npx",
       "args": ["-y", "macos-mail-mcp@latest"],
-      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" }
+      "env": { "PATH": "/absolute/path/to/node/bin:/usr/bin:/bin" }
     }
   }
 }
 ```
 
-Use the **absolute path** to `npx` — GUI apps don't inherit your shell's `PATH`, so a bare `"npx"` usually fails to launch. Find yours with `which npx`:
+Both paths above are placeholders. Use the **absolute path** to `npx` — GUI apps don't inherit your shell's `PATH`, so a bare `"npx"` usually fails to launch, and the correct path differs per install. Find yours with `which npx`:
 
 - Apple Silicon Homebrew: `/opt/homebrew/bin/npx`
 - Intel Homebrew: `/usr/local/bin/npx`
@@ -104,7 +104,7 @@ Or add to Claude Desktop config (`~/Library/Application Support/Claude/claude_de
 {
   "mcpServers": {
     "macos-mail-mcp-dev": {
-      "command": "/opt/homebrew/bin/node",
+      "command": "/absolute/path/to/node",
       "args": ["/path/to/macos-mail-mcp/build/index.js"]
     }
   }


### PR DESCRIPTION
The Registration section told users to point Claude at `node /path/to/macos-mail-mcp/build/index.js`. That serves whatever was last compiled in someone's working tree and can never pick up a release — which contradicts the auto-update behaviour the package actually has.

## What changed

Both registration snippets now use the npx form. The local build is scoped to **development on the server itself**, registered as `macos-mail-mcp-dev` so it does not silently shadow a published copy someone also has registered.

`@latest` is made explicit in the npx commands. **It changes nothing today** — a bare package name already re-resolves, because npm skips the range-satisfies shortcut for a name with no version and fetches the manifest with `preferOnline`. The `"^1.3.0"` that appears in the npx cache is a record of the last install, not a pin. `@latest` takes the tag branch instead, which does not depend on that heuristic, so if npm ever changes it the bare form would freeze on an old version *silently, with no signal*. Cost is one extra download, since the two forms hash to different cache keys.

## Two consequences now written down

Both surprise people, and the second reads like a bug:

- **Updates land at server start, not while running.** A long-running Claude Desktop keeps serving the version it launched with, however new the copy on disk is.
- **The check is a registry round-trip**, so an unreachable registry stops the server starting at all rather than falling back to the cached copy. That is the price of always-current — pinning to avoid it gives up the updates, so it is documented as a trade-off rather than left to be rediscovered and "fixed".

## Scope

Docs only. No version bump, no release-workflow changes. Build clean, 280 tests, 100% coverage of `src/` — `test:coverage` is what CI runs, so I ran that rather than `npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)