### PR TITLE
fix(release): make both workflow inputs settable, and prepare one click

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,11 +1,18 @@
 name: Release prepare
 
-# Step 1 of 2. Run this manually when you want to cut a release.
+# Step 1 of 2. Run this manually when you want to cut a release. One click.
 #
 # Derives the next version from the conventional commits accumulated since the
 # last release tag, runs every check, and pushes a release branch carrying the
 # version bump and changelog entry. It does NOT publish and does NOT open the
 # pull request.
+#
+# There is deliberately no dry-run option here. Every check — build, coverage,
+# audit — runs before the branch is pushed either way, so a dry run bought no
+# safety; it only showed the version number one click earlier. Pushing a branch
+# is reversible: if the version is wrong, delete it and re-run with an explicit
+# `bump`. The irreversible step is publishing, which is a separate workflow with
+# its own guard.
 #
 # Opening the PR is left to you on purpose: a pull request created with
 # GITHUB_TOKEN does not trigger workflow runs, so `ci-ok` would never report and
@@ -23,10 +30,6 @@ on:
         type: choice
         options: [auto, patch, minor, major]
         default: auto
-      dry_run:
-        description: "Report the computed version and stop"
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -88,23 +91,7 @@ jobs:
       - run: npm run test:coverage
       - run: npm audit --audit-level=high
 
-      - name: Report (dry run)
-        if: inputs.dry_run
-        run: |
-          {
-            echo "### Dry run — nothing was pushed"
-            echo
-            echo "| | |"
-            echo "|---|---|"
-            echo "| Current | ${{ steps.version.outputs.current }} |"
-            echo "| Next | **${{ steps.version.outputs.next }}** |"
-            echo "| Bump | ${{ steps.version.outputs.bump }} |"
-            echo
-            echo "All checks passed. Re-run with \`dry_run\` unchecked to push the release branch."
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Push the release branch
-        if: ${{ !inputs.dry_run }}
         env:
           NEXT: ${{ steps.version.outputs.next }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,19 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        # Defaults to a dry run because publishing is irreversible: npm will not
-        # let a version be reissued. "Run workflow" clicked without reading the
-        # form must not ship. Unchecking this is the deliberate act.
-        description: "Run every check and stop before publishing (uncheck to actually ship)"
-        type: boolean
-        default: true
+      mode:
+        # A choice, not a boolean. A `type: boolean` renders as a checkbox that
+        # can be awkward or impossible to toggle depending on the client — and a
+        # checkbox defaulting to "safe" that you cannot untick makes publishing
+        # unreachable, which is a worse failure than the one it guards against.
+        # A dropdown states both options in words and is always selectable.
+        #
+        # Defaults to dry-run because publishing is irreversible: npm will not
+        # let a version be reissued. Choosing "publish" is the deliberate act.
+        description: "dry-run checks everything and stops; publish ships it"
+        type: choice
+        options: [dry-run, publish]
+        default: dry-run
 
 permissions:
   contents: read
@@ -126,17 +132,17 @@ jobs:
       - run: npm audit --audit-level=high
 
       - name: Publish (dry run)
-        if: inputs.dry_run
+        if: inputs.mode == 'dry-run'
         run: |
           npm publish --dry-run
           echo "Dry run — nothing was published, tagged or released."
 
       - name: Publish
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.mode == 'publish' }}
         run: npm publish
 
       - name: Confirm it landed
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.mode == 'publish' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -158,7 +164,7 @@ jobs:
       # Tag and release only after the registry has confirmed the version, so a
       # failed publish never leaves a dangling tag.
       - name: Tag and cut the GitHub release
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.mode == 'publish' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,15 +161,15 @@ npm run dev          # TypeScript watch mode
 Three steps, each requiring a human. Publishing to npm is a Gated action, and **nothing
 publishes as a side effect of merging.**
 
-1. **Run "Release prepare"** from the Actions tab. It derives the next version from the
-   conventional commits since the last release tag, runs build, coverage and audit, and
-   with `dry_run` (the default) reports the version and stops. Re-run with `dry_run`
-   unchecked to push a `release/vX.Y.Z` branch carrying the bump and a changelog entry.
+1. **Run "Release prepare"** from the Actions tab — one click. It derives the next version
+   from the conventional commits since the last release tag, runs build, coverage and audit,
+   then pushes a `release/vX.Y.Z` branch carrying the bump and a changelog entry. `bump`
+   defaults to `auto`; override it when the derived level is not what you want.
 2. **Open the PR yourself** from the link the job prints, edit the changelog, and merge.
    This lands the version bump on `main`. It publishes nothing.
-3. **Run "Release"** when you actually want to ship. It publishes whatever version is on
-   `main` via OIDC, confirms the registry has it, then tags and cuts the GitHub release.
-   It also takes a `dry_run` input that stops short of publishing.
+3. **Run "Release"** when you actually want to ship, choosing `mode: publish`. It publishes
+   whatever version is on `main` via OIDC, confirms the registry has it, then tags and cuts
+   the GitHub release. `mode` defaults to `dry-run`, which runs every check and stops.
 
 Any number of pull requests may land on `main` between releases; merge volume never drives
 the version number. The version is derived once, at prepare time, from everything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,13 @@ result; that path is only reached by invoking the registered handler. Use
 Maintainers only, and it is three deliberate steps — publishing to npm is irreversible.
 
 1. Run **Release prepare** from the Actions tab. It derives the next version from the
-   conventional commits since the last release, runs every check, and by default reports
-   the version without pushing anything. Re-run with `dry_run` unchecked to push a
+   conventional commits since the last release, runs every check, and pushes a
    `release/vX.Y.Z` branch with the bump and changelog entry.
 2. Open the PR from the printed link, tidy the changelog, and merge. This lands the
    version bump on `main` and publishes nothing.
-3. Run **Release** when you want to ship. It publishes the version on `main`, then tags
-   and cuts the GitHub release.
+3. Run **Release** when you want to ship, choosing `mode: publish`. It publishes the
+   version on `main`, then tags and cuts the GitHub release. The default `mode: dry-run`
+   runs every check and stops.
 
 **Merging never publishes.** Pull requests can accumulate on `main` for as long as you
 like; shipping is always an explicit action.

--- a/tests/release/workflow.test.ts
+++ b/tests/release/workflow.test.ts
@@ -38,9 +38,26 @@ describe("release-prepare.yml", () => {
     expect(triggers(wf())).toHaveProperty("workflow_dispatch");
   });
 
-  it("defaults to a dry run so a mis-click cannot open a release", () => {
-    const inputs = triggers(wf()).workflow_dispatch.inputs;
-    expect(inputs.dry_run.default).toBe(true);
+  // Preparing is one click. Every check runs before the branch is pushed either
+  // way, so a dry run bought no safety here — and pushing a branch is
+  // reversible. The irreversible step is publishing, guarded in release.yml.
+  it("takes only a bump input, so preparing is one click", () => {
+    expect(Object.keys(triggers(wf()).workflow_dispatch.inputs)).toEqual(["bump"]);
+  });
+
+  it("offers an explicit bump override alongside auto", () => {
+    expect(triggers(wf()).workflow_dispatch.inputs.bump.options).toEqual([
+      "auto",
+      "patch",
+      "minor",
+      "major",
+    ]);
+  });
+
+  it("pushes the branch unconditionally", () => {
+    const push = steps(wf(), "prepare").find((s) => String(s.name ?? "").includes("Push"));
+    expect(push).toBeDefined();
+    expect(push!.if).toBeUndefined();
   });
 
   // Pushing the branch is all it needs. It deliberately does not open the PR:
@@ -101,11 +118,26 @@ describe("release.yml", () => {
     expect(triggers(wf()).push).toBeUndefined();
   });
 
-  // Raised in review of #24: with dry_run defaulting to false, clicking "Run
-  // workflow" without reading the form publishes for real — and npm will not
-  // let a version be reissued.
+  // Clicking "Run workflow" without reading the form must not ship, since npm
+  // will not let a version be reissued.
   it("defaults to a dry run so a careless click cannot ship", () => {
-    expect(triggers(wf()).workflow_dispatch.inputs.dry_run.default).toBe(true);
+    expect(triggers(wf()).workflow_dispatch.inputs.mode.default).toBe("dry-run");
+  });
+
+  // A boolean renders as a checkbox that can be impossible to toggle in some
+  // clients — and a safe-by-default checkbox you cannot untick makes publishing
+  // unreachable, a worse failure than the one it guards against.
+  it("uses a selectable choice rather than a checkbox", () => {
+    const mode = triggers(wf()).workflow_dispatch.inputs.mode;
+    expect(mode.type).toBe("choice");
+    expect(mode.options).toEqual(["dry-run", "publish"]);
+  });
+
+  it("has no boolean inputs at all", () => {
+    const inputs = triggers(wf()).workflow_dispatch.inputs;
+    for (const [name, spec] of Object.entries<any>(inputs)) {
+      expect(spec.type, `input "${name}" is a boolean`).not.toBe("boolean");
+    }
   });
 
   it("refuses to publish from anywhere but main", () => {
@@ -132,13 +164,28 @@ describe("release.yml", () => {
 
   describe("dry run", () => {
     it.each(["Publish", "Confirm it landed", "Tag and cut the GitHub release"])(
-      "skips %s",
+      "skips %s unless mode is publish",
       (name) => {
         const step = steps(wf(), "publish").find((s) => s.name === name);
         expect(step, `no step named exactly "${name}"`).toBeDefined();
-        expect(String(step!.if ?? "")).toMatch(/!\s*inputs\.dry_run/);
+        expect(String(step!.if ?? "")).toMatch(/inputs\.mode == 'publish'/);
       }
     );
+
+    it("runs the checks in both modes", () => {
+      for (const name of ["npm run build", "npm run test:coverage", "npm audit"]) {
+        const step = steps(wf(), "publish").find((s) => String(s.run ?? "").startsWith(name));
+        expect(step, `no unconditional step running "${name}"`).toBeDefined();
+        expect(step!.if).toBeUndefined();
+      }
+    });
+
+    it("the version guard runs in both modes too", () => {
+      const guard = steps(wf(), "publish").find((s) =>
+        String(s.name ?? "").includes("version is releasable")
+      );
+      expect(guard!.if).toBeUndefined();
+    });
   });
 
   // The head_commit gate raised in review of #24 is gone entirely: with no push


### PR DESCRIPTION
Both problems surfaced by actually trying to run a release, which is the only way either would have shown up.

## The publish input was a trap

`release.yml` used a `type: boolean`, which renders as a checkbox — and a checkbox that cannot be toggled in some clients. It defaulted to `true` for safety, so **an untoggleable checkbox made publishing unreachable entirely**. That is a worse failure than the mis-click it guarded against, and it only appears at the moment someone finally tries to ship.

Now `mode: [dry-run, publish]`, a choice. Dropdowns are always selectable, and naming both options in words beats a checkbox whose meaning depends on reading the label. Still defaults to `dry-run`, because npm will not let a version be reissued.

## The prepare dry-run bought nothing

Build, coverage and audit run before the branch is pushed either way, so a dry run only showed the version one click earlier. Pushing a branch is reversible — wrong version, delete it, re-run with an explicit `bump`. I had applied the caution that belongs to publishing to an operation that does not need it.

Removed. **Preparing is now one click**, and the release is three steps rather than four: prepare → PR → publish.

## Tests

Assert the new shape, and — more usefully — that **neither workflow has any boolean input at all**. The trap was the input type, not this one instance of it. Also pins that the checks and the version guard run in *both* modes, so a dry run is a genuine rehearsal rather than a cheaper path.

131 release tests, 405 total, 100% coverage of `src/` held.

## Note

`main` is unchanged behaviourally — this only touches workflow inputs, their conditions, and the docs describing them. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)