### PR TITLE
fix(release): assert the committed version, not the working tree

### DIFF
--- a/tests/release/workflow.test.ts
+++ b/tests/release/workflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { parse } from "yaml";
 
@@ -273,21 +274,35 @@ describe("release.yml — the whole release in one workflow", () => {
     });
   });
 
+  // Read from git, not the working tree. The claim is about what the REPOSITORY
+  // holds, and the release workflow deliberately rewrites the working copy
+  // before running these very checks — reading the tree made this assert the
+  // opposite of its intent and failed the first real release at 1.3.1.
   describe("package.json version is a placeholder", () => {
-    const pkg = () => JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8"));
-    const lock = () =>
-      JSON.parse(readFileSync(join(process.cwd(), "package-lock.json"), "utf8"));
+    const committed = (file: string) =>
+      JSON.parse(execFileSync("git", ["show", `HEAD:${file}`], { encoding: "utf8" }));
 
     it("is not a release version", () => {
-      expect(pkg().version).toBe("0.0.0-development");
+      expect(committed("package.json").version).toBe("0.0.0-development");
     });
 
     // Raised in review of #27: the lockfile kept 1.3.0 after the manifest moved
     // to the placeholder. npm ci tolerates the drift, but npm install silently
     // rewrites the lockfile, so it comes back as noise in an unrelated diff.
     it("matches the lockfile", () => {
-      expect(lock().version).toBe(pkg().version);
-      expect(lock().packages[""].version).toBe(pkg().version);
+      const pkg = committed("package.json");
+      const lock = committed("package-lock.json");
+      expect(lock.version).toBe(pkg.version);
+      expect(lock.packages[""].version).toBe(pkg.version);
+    });
+
+    // The failure this pair caused was invisible until a release ran, because
+    // nothing else mutates the tree. Pin the property directly.
+    it("is unaffected by the working tree being rewritten", () => {
+      const before = committed("package.json").version;
+      expect(before).toBe("0.0.0-development");
+      expect(JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")).version)
+        .toBeTypeOf("string");
     });
   });
 });

--- a/tests/release/workflow.test.ts
+++ b/tests/release/workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { parse } from "yaml";
@@ -296,13 +296,30 @@ describe("release.yml — the whole release in one workflow", () => {
       expect(lock.packages[""].version).toBe(pkg.version);
     });
 
-    // The failure this pair caused was invisible until a release ran, because
-    // nothing else mutates the tree. Pin the property directly.
-    it("is unaffected by the working tree being rewritten", () => {
-      const before = committed("package.json").version;
-      expect(before).toBe("0.0.0-development");
-      expect(JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")).version)
-        .toBeTypeOf("string");
+    // Proves committed() reads git rather than the working tree, by making the
+    // two disagree — the earlier version of this test asserted nothing, since
+    // it never rewrote anything and would have passed either way.
+    //
+    // It mutates package-lock.json, not package.json: both go through the same
+    // committed() helper, but tests/index.test.ts reads package.json and vitest
+    // runs test files in parallel, so mutating that one would intermittently
+    // break an unrelated suite.
+    it("reads git even when the working tree disagrees", () => {
+      const path = join(process.cwd(), "package-lock.json");
+      const original = readFileSync(path, "utf8");
+      try {
+        writeFileSync(
+          path,
+          JSON.stringify({ ...JSON.parse(original), version: "9.9.9-tree-only" }, null, 2)
+        );
+
+        // The working tree now disagrees with HEAD…
+        expect(JSON.parse(readFileSync(path, "utf8")).version).toBe("9.9.9-tree-only");
+        // …and the assertion still reports what git holds.
+        expect(committed("package-lock.json").version).toBe("0.0.0-development");
+      } finally {
+        writeFileSync(path, original);
+      }
     });
   });
 });


### PR DESCRIPTION
The first real release failed at 1.3.1, on a test I added two rounds ago:

```
AssertionError: expected '1.3.1' to be '0.0.0-development'
```

**Two things I built contradicted each other.** The workflow applies the version to the working tree *before* the checks, so they verify the exact tree that ships. The placeholder test read that same working tree and asserted it still held `0.0.0-development`. Each is defensible alone; together, a release could never pass its own suite.

The test's claim is about what the **repository** holds, not what the runner's working copy holds at one instant. It now reads `git show HEAD:package.json`, which states that directly and is immune to the tree being rewritten. The lockfile-consistency check reads the same way.

## Nothing was published

The failure landed before the publish step. No version on npm, no tag, nothing on `main` — the ordering working exactly as designed. Under the old tag-triggered pipeline this would have left `v1.3.1` pointing at nothing, which is the failure that started this whole redesign.

## Verified against the real condition

```
$ npm version --no-git-tag-version 1.3.1   # what the release does
$ npx vitest run tests/release
  Tests  128 passed
```

Previously that mutation was the failure. A third test pins the property, so this cannot regress into something only a live release can discover — which is what made it expensive: every check was green on `main`, because nothing else rewrites the tree.

408 tests, 100% coverage of `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)