### PR TITLE
fix: guard escapeForJson against multi-codepoint grapheme clusters

### DIFF
--- a/src/bridge/escape-for-json.applescript
+++ b/src/bridge/escape-for-json.applescript
@@ -33,11 +33,17 @@ on escapeForJson(theString)
     set theString to parts as text
 
     -- Escape other C0 control characters (0-8, 11-12, 14-31)
+    -- Note: "id of c" returns a list of code points (not a single integer) when c is a
+    -- multi-codepoint grapheme cluster (e.g. an emoji + variation selector, or a base
+    -- letter + combining diacritic such as decomposed "é"). Comparing such a list with
+    -- ">=" / "<=" raises "Can't make {…} into type number, date or text" (-1700).
+    -- Real C0 control characters are always single code points, so it's safe to only
+    -- treat cCode as a control character when it is a plain integer.
     set resultList to {}
     repeat with i from 1 to length of theString
         set c to character i of theString
         set cCode to id of c
-        if cCode >= 0 and cCode <= 31 then
+        if (class of cCode is integer) and cCode >= 0 and cCode <= 31 then
             set hexChars to "0123456789abcdef"
             set hi to (cCode div 16) + 1
             set lo to (cCode mod 16) + 1


### PR DESCRIPTION
## Summary

`escapeForJson` (used by `list-mailboxes`, `list-messages`, `search-messages`, `list-attachments`, and everywhere else names get JSON-encoded) crashes with `Can't make {…} into type number, date or text (-1700)` whenever a mailbox/account/subject/sender name contains a "character" that AppleScript represents as a multi-codepoint grapheme cluster — e.g. an emoji followed by a variation selector (🎎️ = U+1F38E + U+FE0F), or a base letter followed by a combining diacritic (decomposed "é" = U+0065 + U+0301).

In that case `id of c` returns a **list** of the constituent code points instead of a single integer. The existing check `if cCode >= 0 and cCode <= 31 then` then tries to compare that list against an integer, which AppleScript can't coerce, producing the crash. Since these tools iterate all mailboxes in an account to resolve a mailbox by name, a single such folder/message anywhere in the account breaks every listing/search call for that whole account.

## Fix

Only treat `cCode` as a control character when it actually is a plain integer:

```applescript
if (class of cCode is integer) and cCode >= 0 and cCode <= 31 then
```

This is safe because real C0 control characters (0–31) are always single code points — they can never be part of a combined grapheme cluster — so no control character that was previously escaped can be missed by this check.

## Repro

```applescript
set theString to "🎎️test"
repeat with i from 1 to length of theString
    set c to character i of theString
    set cCode to id of c
    if cCode >= 0 and cCode <= 31 then
        log "control char"
    end if
end repeat
```
raises `Can't make {127886, 65039} into type number, date or text (-1700)` on the emoji character, reproducing the exact class of error seen against a real Mail.app account with an emoji-named folder.

## Test plan
- [x] Reproduced the crash in isolation with `osascript` against a string containing an emoji+variation-selector grapheme
- [x] Verified the patched comparison no longer crashes on that string, on a decomposed "é", on a tab (still escaped to `\t`), and on plain ASCII text
- [x] `npm test` — 19 test files, 408 tests, all passing