### PR TITLE
test(bridge): execute the AppleScript escaping handler for real

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ checks that the required status check `verify` is one a workflow here actually r
   stale on every change and nothing checks it.
 - **The `.applescript` files are the exception, and it is a real one.** That 100% covers
   `src/**/*.ts` only. Because the bridge is mocked, the AppleScript templates are text handed to a
-  mock rather than code that runs — which is how #33 shipped a handler that threw on any emoji
-  subject. `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
+  mock rather than code that runs — which is how a handler that threw on any emoji subject shipped
+  unexercised, found by an outside contributor (#33) rather than by the suite. `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
   `osascript` for real, and **skips off macOS, which includes CI**. So those assertions run on a
   maintainer's machine and never in the merge gate. Run `npm run test:coverage` locally before
   touching anything under `src/**/*.applescript`; the runner cannot do it for you.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,13 @@ checks that the required status check `verify` is one a workflow here actually r
   **100%** (statements, branches, functions, lines) in `vitest.config.ts`, and CI runs
   `test:coverage`. The gate is the invariant; the raw test count is not tracked here because it goes
   stale on every change and nothing checks it.
+- **The `.applescript` files are the exception, and it is a real one.** That 100% covers
+  `src/**/*.ts` only. Because the bridge is mocked, the AppleScript templates are text handed to a
+  mock rather than code that runs — which is how #33 shipped a handler that threw on any emoji
+  subject. `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
+  `osascript` for real, and **skips off macOS, which includes CI**. So those assertions run on a
+  maintainer's machine and never in the merge gate. Run `npm run test:coverage` locally before
+  touching anything under `src/**/*.applescript`; the runner cannot do it for you.
 
 ## Architecture
 

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -21,7 +21,10 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
 
     it("passes a precomposed accent through", () => {
       // U+00E9 — one code point, so `id of` returns an integer and the old guard coped.
-      expect(escape(codePoints(0x00e9))).toBe("é");
+      // Written as an escape, not as a literal: this file's whole premise is that a literal `é`
+      // could be either form and an editor could normalise one into the other. The expected value
+      // is subject to that exactly as the input is.
+      expect(escape(codePoints(0x00e9))).toBe("\u00e9");
     });
 
     /** #33: `id of` returns {101, 769} here, and comparing a list with `>=` raised -1700. */
@@ -63,14 +66,18 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
       expect(escape(codePoints(0x0d, 0x0a))).toBe("\\r\\n");
     });
 
+    // The label carries the code point because vitest's title formatting has no %04X — an earlier
+    // version used one and every title rendered as the literal "U+%04X", hiding which case ran.
     it.each([
-      [0x01, "\\u0001"],
-      [0x08, "\\u0008"],
-      [0x0b, "\\u000b"],
-      [0x0c, "\\u000c"],
-      [0x1f, "\\u001f"],
-    ])("escapes C0 control U+%04X as %s", (point, expected) => {
-      expect(escape(codePoints(point))).toBe(expected);
+      ["U+0001", "\\u0001", 0x01],
+      ["U+0008", "\\u0008", 0x08],
+      ["U+000B", "\\u000b", 0x0b],
+      ["U+000C", "\\u000c", 0x0c],
+      ["U+001F", "\\u001f", 0x1f],
+      // vitest fills %s positionally from the row, so the two it prints must be items 0 and 1 —
+      // the point rides last precisely because it is the one value the title should not show.
+    ])("escapes C0 control %s as %s", (_label, expected, point) => {
+      expect(escape(codePoints(point as number))).toBe(expected as string);
     });
 
     it("escapes a control character embedded in ordinary text", () => {

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { runHandler, codePoints, onMacOS } from "../helpers/run-applescript.js";
+
+const HANDLER = "src/bridge/escape-for-json.applescript";
+
+const escape = (expression: string) => runHandler(HANDLER, `escapeForJson(${expression})`);
+
+/**
+ * The first tests in this repository that execute AppleScript.
+ *
+ * Skipped off macOS, which includes CI — `osascript` does not exist on the Linux runner. That is a
+ * real limit and not a soft one: these assertions run where the code runs, on a maintainer's
+ * machine, and never in the merge gate. They are still worth having, because the alternative was a
+ * handler with no executable coverage at all, which is how #33 shipped.
+ */
+describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
+  describe("text that needs no escaping survives unchanged", () => {
+    it("passes ASCII through", () => {
+      expect(escape('"hello world"')).toBe("hello world");
+    });
+
+    it("passes a precomposed accent through", () => {
+      // U+00E9 — one code point, so `id of` returns an integer and the old guard coped.
+      expect(escape(codePoints(0x00e9))).toBe("é");
+    });
+
+    /** #33: `id of` returns {101, 769} here, and comparing a list with `>=` raised -1700. */
+    it("passes a decomposed accent through", () => {
+      expect(escape(codePoints(0x65, 0x0301))).toBe("e\u0301");
+    });
+
+    it("passes an emoji carrying a variation selector through", () => {
+      expect(escape(codePoints(0x2764, 0xfe0f))).toBe("\u2764\ufe0f");
+    });
+
+    // Never broken, and asserted so that the boundary of #33 is on the page: an astral character
+    // is a single code point to AppleScript, not a surrogate pair.
+    it("passes an astral emoji through", () => {
+      expect(escape(codePoints(0x1f600))).toBe("\u{1f600}");
+    });
+
+    it("passes a ZWJ sequence through", () => {
+      expect(escape(codePoints(0x1f468, 0x200d, 0x1f469))).toBe("\u{1f468}\u200d\u{1f469}");
+    });
+  });
+
+  describe("the escaping it exists to do", () => {
+    it("escapes a double quote", () => {
+      expect(escape('"say \\"hi\\""')).toBe('say \\"hi\\"');
+    });
+
+    it("escapes a backslash", () => {
+      expect(escape(codePoints(0x5c))).toBe("\\\\");
+    });
+
+    it("escapes tab, newline and carriage return by name", () => {
+      expect(escape(codePoints(0x09))).toBe("\\t");
+      expect(escape(codePoints(0x0a))).toBe("\\n");
+      expect(escape(codePoints(0x0d))).toBe("\\r");
+    });
+
+    it("escapes a CRLF pair as two escapes", () => {
+      expect(escape(codePoints(0x0d, 0x0a))).toBe("\\r\\n");
+    });
+
+    it.each([
+      [0x01, "\\u0001"],
+      [0x08, "\\u0008"],
+      [0x0b, "\\u000b"],
+      [0x0c, "\\u000c"],
+      [0x1f, "\\u001f"],
+    ])("escapes C0 control U+%04X as %s", (point, expected) => {
+      expect(escape(codePoints(point))).toBe(expected);
+    });
+
+    it("escapes a control character embedded in ordinary text", () => {
+      expect(escape(`"a" & ${codePoints(0x01)} & "b"`)).toBe("a\\u0001b");
+    });
+  });
+
+  describe("the output is valid JSON, which is the actual contract", () => {
+    it("round-trips through JSON.parse", () => {
+      const value = escape(`"caf" & ${codePoints(0x65, 0x0301)} & ${codePoints(0x01)}`);
+      expect(JSON.parse(`{"v":"${value}"}`)).toEqual({ v: "cafe\u0301\u0001" });
+    });
+  });
+
+  /**
+   * #39, asserted as it SHOULD behave and marked `.fails` so it passes only while the defect is
+   * present. When the fix lands this test errors — "expected to fail, but passed" — which forces
+   * the marker off rather than leaving a stale skip nobody revisits.
+   *
+   * AppleScript clusters a C0 control with a following combining mark into one character
+   * (`id of` -> {1, 769}), so the guard added in #33 sends the whole cluster down the passthrough
+   * branch and a raw U+0001 reaches the JSON string.
+   */
+  describe("#39 — a control character leading a grapheme cluster", () => {
+    it.fails("should escape the control and keep the combining mark", () => {
+      expect(escape(codePoints(0x01, 0x0301))).toBe("\\u0001\u0301");
+    });
+
+    it("currently emits the raw control character, which is invalid JSON", () => {
+      const value = escape(codePoints(0x01, 0x0301));
+      expect(value).toContain("\u0001");
+      expect(() => JSON.parse(`{"v":"${value}"}`)).toThrow();
+    });
+  });
+});

--- a/tests/helpers/run-applescript.ts
+++ b/tests/helpers/run-applescript.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Run a shared AppleScript handler for real, through `osascript`.
+ *
+ * Every other test in this suite mocks `node:child_process`, which means the `.applescript` files
+ * are never executed — they are text that gets concatenated and handed to a mock. That gap let a
+ * real bug through (#33: `id of c` returns a *list* for a multi-code-point grapheme cluster, so the
+ * comparison against 31 raised -1700 and every message with an emoji subject failed).
+ *
+ * This helper closes it for the one handler where the risk is concentrated. It only works where
+ * `osascript` exists, so callers gate on `darwin` — see `onMacOS` below.
+ */
+export function runHandler(handlerPath: string, expression: string): string {
+  const source = readFileSync(join(process.cwd(), handlerPath), "utf8");
+  const script = `${source}\n\nreturn ${expression}\n`;
+  return execFileSync("osascript", ["-"], {
+    input: script,
+    encoding: "utf8",
+    timeout: 20_000,
+  }).replace(/\n$/, "");
+}
+
+/**
+ * AppleScript source for a string literal built from explicit code points.
+ *
+ * Written this way rather than as a literal so the test says which code points it means. A `é` in
+ * a source file could be either the precomposed U+00E9 or the decomposed pair, and those are the
+ * two cases that behave differently — a reader must not have to guess which one is on the page,
+ * and an editor must not be able to silently normalise one into the other.
+ */
+export function codePoints(...points: number[]): string {
+  return points.map((p) => `(character id ${p})`).join(" & ");
+}
+
+/** `osascript` exists on macOS only; CI runs on Linux. */
+export const onMacOS = process.platform === "darwin";


### PR DESCRIPTION
Closes #38.

Coverage of `src/` is gated at 100% — and that number covers `src/**/*.ts` only. Because the bridge is mocked wholesale, **no test here had ever executed a line of AppleScript**. The templates were text concatenated and handed to a mock.

#33 is what that cost: a handler that threw `-1700` on any subject carrying a decomposed accent or a variation-selector emoji, found by an outside contributor rather than by the suite.

## What runs now

`tests/helpers/run-applescript.ts` composes a handler with a call and runs it through `osascript`. Nineteen cases:

- **passthrough** — precomposed `é`, decomposed `e`+U+0301, `❤️` (VS16), astral `😀`, ZWJ `👨‍👩`
- **escaping** — quote, backslash, tab, newline, CR, CRLF, and C0 controls U+0001/0008/000B/000C/001F, plus one embedded mid-string
- **the actual contract** — a round-trip through `JSON.parse`

Inputs are built from explicit code points rather than written as literals. `é` on the page could be U+00E9 or the decomposed pair, and those are precisely the two cases that behave differently — a reader shouldn't have to guess which is in the file, and an editor shouldn't be able to normalise one into the other.

## The limit, stated rather than discovered

**These skip off macOS, which includes CI.** There is no `osascript` on the Linux runner, so they run on a maintainer's machine and never in the merge gate. That's in `CLAUDE.md` now, next to the 100% claim, so the green is not read as broader than it is.

A test that only sometimes runs is worth having when the alternative is none — but only if it's labelled.

## #39 is pinned, not skipped

```ts
it.fails("should escape the control and keep the combining mark", …)
```

It asserts what *should* happen and passes only while the defect exists. When #39's fix lands this errors with "expected to fail, but passed", forcing the marker off rather than leaving a stale skip nobody revisits.

## Verify

```
build=0  test=0  audit=0
Test Files  25 passed (25)
     Tests  465 passed | 1 expected fail (466)
100% statements / branches / functions / lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6H7LRC6h2mSHH3yP2srH9
