### PR TITLE
fix: judge every code point of a grapheme cluster, not only single ones

### DIFF
--- a/src/bridge/escape-for-json.applescript
+++ b/src/bridge/escape-for-json.applescript
@@ -32,10 +32,10 @@ on escapeForJson(theString)
     set AppleScript's text item delimiters to "\\r"
     set theString to parts as text
 
-    -- Escape other C0 control characters (0-8, 11-12, 14-31)
+    -- Escape whatever the delimiter phases above could not reach
     -- "id of c" returns a LIST of code points, not an integer, when c is a multi-code-point
     -- grapheme cluster -- an emoji plus a variation selector, a base letter plus a combining
-    -- diacritic (decomposed "é"), a ZWJ sequence. Comparing that list with ">=" raises
+    -- diacritic (decomposed "e"), a ZWJ sequence. Comparing that list with ">=" raises
     -- "Can't make {...} into type number, date or text" (-1700), which is what #33 fixed.
     --
     -- #33 fixed it by escaping only when the id is a plain integer, on the reasoning that a real
@@ -44,9 +44,16 @@ on escapeForJson(theString)
     -- `id of` returns {1, 769} and the whole cluster took the passthrough branch -- emitting a raw
     -- control character into a JSON string, which no parser accepts. #39.
     --
-    -- So the id is normalised to a list and every code point is judged on its own. A cluster
-    -- containing no control emits exactly the code points it arrived with, which is the same text;
-    -- one that leads with a control gets the control escaped and the rest kept.
+    -- The delimiter phases above are CLUSTER-BLIND: `text items of` does not split on a quote,
+    -- backslash, tab, LF or CR that sits inside a grapheme cluster. So everything JSON requires
+    -- escaping can still be raw at this point, but only inside a cluster. That is why the two
+    -- branches below judge different things, and the asymmetry is the whole correctness argument:
+    --
+    --   * A single code point has ALREADY been through those phases. A quote here is the second
+    --     half of a `\"` they produced, and escaping it again would yield `\\"`. So this branch
+    --     escapes controls and touches nothing else.
+    --   * A cluster has NOT. Every code point in it is still raw, so each is judged on its own --
+    --     controls, quote and backslash alike.
     set resultList to {}
     set hexChars to "0123456789abcdef"
     repeat with i from 1 to length of theString
@@ -54,21 +61,29 @@ on escapeForJson(theString)
         set cCode to id of c
 
         if class of cCode is integer then
-            set codePoints to {cCode}
-        else
-            set codePoints to cCode
-        end if
-
-        repeat with j from 1 to (count of codePoints)
-            set pt to (item j of codePoints) as integer
-            if pt >= 0 and pt <= 31 then
-                set hi to (pt div 16) + 1
-                set lo to (pt mod 16) + 1
+            if cCode >= 0 and cCode <= 31 then
+                set hi to (cCode div 16) + 1
+                set lo to (cCode mod 16) + 1
                 copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
             else
-                copy (character id pt) to end of resultList
+                copy c to end of resultList
             end if
-        end repeat
+        else
+            repeat with j from 1 to (count of cCode)
+                set pt to (item j of cCode) as integer
+                if pt >= 0 and pt <= 31 then
+                    set hi to (pt div 16) + 1
+                    set lo to (pt mod 16) + 1
+                    copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
+                else if pt = 34 then
+                    copy "\\\"" to end of resultList
+                else if pt = 92 then
+                    copy "\\\\" to end of resultList
+                else
+                    copy (character id pt) to end of resultList
+                end if
+            end repeat
+        end if
     end repeat
 
     set AppleScript's text item delimiters to ""

--- a/src/bridge/escape-for-json.applescript
+++ b/src/bridge/escape-for-json.applescript
@@ -33,24 +33,42 @@ on escapeForJson(theString)
     set theString to parts as text
 
     -- Escape other C0 control characters (0-8, 11-12, 14-31)
-    -- Note: "id of c" returns a list of code points (not a single integer) when c is a
-    -- multi-codepoint grapheme cluster (e.g. an emoji + variation selector, or a base
-    -- letter + combining diacritic such as decomposed "é"). Comparing such a list with
-    -- ">=" / "<=" raises "Can't make {…} into type number, date or text" (-1700).
-    -- Real C0 control characters are always single code points, so it's safe to only
-    -- treat cCode as a control character when it is a plain integer.
+    -- "id of c" returns a LIST of code points, not an integer, when c is a multi-code-point
+    -- grapheme cluster -- an emoji plus a variation selector, a base letter plus a combining
+    -- diacritic (decomposed "é"), a ZWJ sequence. Comparing that list with ">=" raises
+    -- "Can't make {...} into type number, date or text" (-1700), which is what #33 fixed.
+    --
+    -- #33 fixed it by escaping only when the id is a plain integer, on the reasoning that a real
+    -- control character is always a single code point. That reasoning is wrong, and measurably:
+    -- AppleScript clusters a C0 control with a following combining mark into ONE character, so
+    -- `id of` returns {1, 769} and the whole cluster took the passthrough branch -- emitting a raw
+    -- control character into a JSON string, which no parser accepts. #39.
+    --
+    -- So the id is normalised to a list and every code point is judged on its own. A cluster
+    -- containing no control emits exactly the code points it arrived with, which is the same text;
+    -- one that leads with a control gets the control escaped and the rest kept.
     set resultList to {}
+    set hexChars to "0123456789abcdef"
     repeat with i from 1 to length of theString
         set c to character i of theString
         set cCode to id of c
-        if (class of cCode is integer) and cCode >= 0 and cCode <= 31 then
-            set hexChars to "0123456789abcdef"
-            set hi to (cCode div 16) + 1
-            set lo to (cCode mod 16) + 1
-            copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
+
+        if class of cCode is integer then
+            set codePoints to {cCode}
         else
-            copy c to end of resultList
+            set codePoints to cCode
         end if
+
+        repeat with j from 1 to (count of codePoints)
+            set pt to (item j of codePoints) as integer
+            if pt >= 0 and pt <= 31 then
+                set hi to (pt div 16) + 1
+                set lo to (pt mod 16) + 1
+                copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
+            else
+                copy (character id pt) to end of resultList
+            end if
+        end repeat
     end repeat
 
     set AppleScript's text item delimiters to ""

--- a/src/bridge/escape-for-json.applescript
+++ b/src/bridge/escape-for-json.applescript
@@ -1,91 +1,61 @@
+-- Escape a string for embedding in a JSON string literal.
+--
+-- ## One pass over code points, and no text item delimiters
+--
+-- Earlier versions escaped the named characters with five text-item-delimiter passes and then
+-- swept the rest character by character. That shape kept producing bugs, and the last round
+-- explained why: `text items of` does not have grapheme-cluster semantics, and it does not have
+-- one consistent non-cluster semantics either. Measured on this handler's own inputs:
+--
+--   * backslash + U+0301 (combining mark)  -> 1 text item. The delimiter does not see inside.
+--   * backslash + U+200D (ZWJ) + "A"       -> 2 text items. It DOES see inside, matches the
+--                                             backslash, and orphans the ZWJ.
+--   * quote + U+200C (ZWNJ) + "A"          -> 1 text item, though these are three separate
+--                                             characters. It refuses to match a bare quote.
+--
+-- So whether a phase sees a character depended on which extender followed it. #33 fixed the
+-- symptom for combining marks; a later fix judged code points inside clusters, which double-escaped
+-- the ZWJ case because the phase had already inserted a backslash that then re-clustered. Each fix
+-- was reasoned from one extender's behaviour and generalised to all of them.
+--
+-- `id of theString` has none of that. It returns the string's code points, flat: no clustering, no
+-- collation, no matching. Every code point is then judged once, on its own, and nothing earlier in
+-- the handler can have altered it. The cases above stop being special because there are no phases
+-- left for them to be special about.
+--
+-- (`id of` returns a bare integer for a one-character string and an empty list for an empty one,
+-- so the result is normalised to a list before the loop.)
 on escapeForJson(theString)
-    -- Use text item delimiters for O(n) performance instead of character-by-character O(n²)
-    set oldDelims to AppleScript's text item delimiters
+    set codePoints to id of theString
+    if class of codePoints is integer then set codePoints to {codePoints}
 
-    -- Escape backslashes first
-    set AppleScript's text item delimiters to "\\"
-    set parts to text items of theString
-    set AppleScript's text item delimiters to "\\\\"
-    set theString to parts as text
-
-    -- Escape double quotes
-    set AppleScript's text item delimiters to "\""
-    set parts to text items of theString
-    set AppleScript's text item delimiters to "\\\""
-    set theString to parts as text
-
-    -- Escape tabs (ASCII 9)
-    set AppleScript's text item delimiters to (ASCII character 9)
-    set parts to text items of theString
-    set AppleScript's text item delimiters to "\\t"
-    set theString to parts as text
-
-    -- Escape newlines (ASCII 10)
-    set AppleScript's text item delimiters to (ASCII character 10)
-    set parts to text items of theString
-    set AppleScript's text item delimiters to "\\n"
-    set theString to parts as text
-
-    -- Escape carriage returns (ASCII 13)
-    set AppleScript's text item delimiters to (ASCII character 13)
-    set parts to text items of theString
-    set AppleScript's text item delimiters to "\\r"
-    set theString to parts as text
-
-    -- Escape whatever the delimiter phases above could not reach
-    -- "id of c" returns a LIST of code points, not an integer, when c is a multi-code-point
-    -- grapheme cluster -- an emoji plus a variation selector, a base letter plus a combining
-    -- diacritic (decomposed "e"), a ZWJ sequence. Comparing that list with ">=" raises
-    -- "Can't make {...} into type number, date or text" (-1700), which is what #33 fixed.
-    --
-    -- #33 fixed it by escaping only when the id is a plain integer, on the reasoning that a real
-    -- control character is always a single code point. That reasoning is wrong, and measurably:
-    -- AppleScript clusters a C0 control with a following combining mark into ONE character, so
-    -- `id of` returns {1, 769} and the whole cluster took the passthrough branch -- emitting a raw
-    -- control character into a JSON string, which no parser accepts. #39.
-    --
-    -- The delimiter phases above are CLUSTER-BLIND: `text items of` does not split on a quote,
-    -- backslash, tab, LF or CR that sits inside a grapheme cluster. So everything JSON requires
-    -- escaping can still be raw at this point, but only inside a cluster. That is why the two
-    -- branches below judge different things, and the asymmetry is the whole correctness argument:
-    --
-    --   * A single code point has ALREADY been through those phases. A quote here is the second
-    --     half of a `\"` they produced, and escaping it again would yield `\\"`. So this branch
-    --     escapes controls and touches nothing else.
-    --   * A cluster has NOT. Every code point in it is still raw, so each is judged on its own --
-    --     controls, quote and backslash alike.
-    set resultList to {}
     set hexChars to "0123456789abcdef"
-    repeat with i from 1 to length of theString
-        set c to character i of theString
-        set cCode to id of c
+    set resultList to {}
 
-        if class of cCode is integer then
-            if cCode >= 0 and cCode <= 31 then
-                set hi to (cCode div 16) + 1
-                set lo to (cCode mod 16) + 1
-                copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
-            else
-                copy c to end of resultList
-            end if
+    repeat with i from 1 to (count of codePoints)
+        set pt to (item i of codePoints) as integer
+
+        if pt = 34 then
+            copy "\\\"" to end of resultList
+        else if pt = 92 then
+            copy "\\\\" to end of resultList
+        else if pt = 9 then
+            copy "\\t" to end of resultList
+        else if pt = 10 then
+            copy "\\n" to end of resultList
+        else if pt = 13 then
+            copy "\\r" to end of resultList
+        else if pt >= 0 and pt <= 31 then
+            -- The rest of C0. JSON requires these escaped and gives them no short form.
+            set hi to (pt div 16) + 1
+            set lo to (pt mod 16) + 1
+            copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
         else
-            repeat with j from 1 to (count of cCode)
-                set pt to (item j of cCode) as integer
-                if pt >= 0 and pt <= 31 then
-                    set hi to (pt div 16) + 1
-                    set lo to (pt mod 16) + 1
-                    copy ("\\u00" & character hi of hexChars & character lo of hexChars) to end of resultList
-                else if pt = 34 then
-                    copy "\\\"" to end of resultList
-                else if pt = 92 then
-                    copy "\\\\" to end of resultList
-                else
-                    copy (character id pt) to end of resultList
-                end if
-            end repeat
+            copy (character id pt) to end of resultList
         end if
     end repeat
 
+    set oldDelims to AppleScript's text item delimiters
     set AppleScript's text item delimiters to ""
     set resultStr to resultList as text
     set AppleScript's text item delimiters to oldDelims

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -93,18 +93,15 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
   });
 
   /**
-   * #39, and the class it belongs to.
+   * #39, and the class it turned out to belong to.
    *
-   * The delimiter phases at the top of the handler are cluster-blind: `text items of` does not
-   * split on a character that sits inside a grapheme cluster. So anything JSON requires escaping
-   * can still be raw when the per-character loop is reached — but only inside a cluster.
-   *
-   * These were `it.fails` while the defect stood. They are ordinary assertions now.
+   * The handler no longer has delimiter phases, so "inside a cluster" is not a category it can
+   * treat differently — every code point is judged once, on its own. These cases are kept because
+   * they are the ones that were broken, and because each broke a different earlier design.
    */
-  describe("#39 — characters JSON must escape, hidden inside a grapheme cluster", () => {
-    it("escapes a control code point wherever it sits in the cluster", () => {
+  describe("#39 — characters JSON must escape, next to a combining mark", () => {
+    it("escapes a control code point wherever it sits", () => {
       expect(escape(codePoints(0x01, 0x0301))).toBe("\\u0001\u0301");
-      // Not only when it leads: the loop judges every code point.
       expect(escape(codePoints(0x65, 0x0301, 0x01))).toBe("e\u0301\\u0001");
     });
 
@@ -114,42 +111,56 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
       expect(JSON.parse(`{"v":"${value}"}`)).toEqual({ v: "\u0001\u0301" });
     });
 
-    /**
-     * Found by the supervisor pass, and it is the same defect one column over: a quote or
-     * backslash clustered with a combining mark reached the output raw, because the loop's only
-     * judgment was the control range.
-     */
-    it("escapes a quote and a backslash clustered with a combining mark", () => {
+    it("escapes a quote and a backslash next to a combining mark", () => {
       expect(escape(codePoints(0x22, 0x0301))).toBe('\\"\u0301');
       expect(escape(codePoints(0x5c, 0x0301))).toBe("\\\\\u0301");
     });
 
-    /**
-     * The guard on the fix for the line above. By the time the loop runs, the delimiter phases
-     * have already turned a bare quote into `\"` — two single-code-point characters. Escaping 34
-     * and 92 unconditionally would re-escape that half into `\\"`, breaking every quoted string.
-     * The escaping is therefore confined to the cluster branch, and this pins it.
-     */
-    it("does not double-escape a quote or backslash the delimiter phases already handled", () => {
+    it("does not double-escape a bare quote or backslash", () => {
       expect(escape(codePoints(0x22))).toBe('\\"');
       expect(escape(codePoints(0x5c))).toBe("\\\\");
       expect(escape('"say \\"hi\\" \\\\ done"')).toBe('say \\"hi\\" \\\\ done');
     });
 
-    /**
-     * Named controls are handled by their own delimiter phases, which are equally cluster-blind —
-     * so inside a cluster they fall through to the C0 loop and come out as \u00XX rather than \t.
-     * Both are valid JSON. Pinned because a future "tab is already handled above" tidy-up would
-     * regress this invisibly.
-     */
     it.each([
-      ["tab", 0x09, "\\u0009"],
-      ["newline", 0x0a, "\\u000a"],
-      ["carriage return", 0x0d, "\\u000d"],
-    ])("escapes a %s clustered with a combining mark", (_name, point, expected) => {
-      const value = escape(codePoints(point as number, 0x0301));
-      expect(value).toBe(`${expected}\u0301`);
+      ["tab", 0x09, "\\t"],
+      ["newline", 0x0a, "\\n"],
+      ["carriage return", 0x0d, "\\r"],
+    ])("escapes a %s next to a combining mark, by its short form", (_name, point, expected) => {
+      expect(escape(codePoints(point as number, 0x0301))).toBe(`${expected}\u0301`);
+    });
+  });
+
+  /**
+   * The regression the supervisor pass found, and the reason the delimiter phases are gone.
+   *
+   * `text items of` had no single behaviour to reason from — measured, it was blind to a
+   * backslash followed by U+0301, split a cluster containing one followed by U+200D (matching the
+   * backslash and orphaning the ZWJ), and refused to match a bare quote followed by U+200C. Every
+   * phase-based design got one of these wrong: the ZWJ cases were valid on main and broken by the
+   * cluster-branch fix, the ZWNJ case was broken on both.
+   */
+  describe("zero-width joiners and non-joiners", () => {
+    it.each([
+      ["quote + ZWJ", [0x22, 0x200d, 0x41], '\\"\u200dA'],
+      ["backslash + ZWJ", [0x5c, 0x200d, 0x41], "\\\\\u200dA"],
+      ["backslash + ZWJ + quote", [0x5c, 0x200d, 0x22], '\\\\\u200d\\"'],
+      ["quote + ZWNJ", [0x22, 0x200c, 0x41], '\\"\u200cA'],
+    ])("escapes %s and stays valid JSON", (_name, points, expected) => {
+      const value = escape(codePoints(...(points as number[])));
+      expect(value).toBe(expected);
       expect(() => JSON.parse(`{"v":"${value}"}`)).not.toThrow();
+    });
+  });
+
+  describe("degenerate input", () => {
+    it("returns the empty string unchanged", () => {
+      // `id of ""` is an empty list rather than an integer, which the normalisation must survive.
+      expect(escape('""')).toBe("");
+    });
+
+    it("handles a single-character string, whose id is an integer not a list", () => {
+      expect(escape('"A"')).toBe("A");
     });
   });
 });

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -93,23 +93,26 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
   });
 
   /**
-   * #39, asserted as it SHOULD behave and marked `.fails` so it passes only while the defect is
-   * present. When the fix lands this test errors — "expected to fail, but passed" — which forces
-   * the marker off rather than leaving a stale skip nobody revisits.
+   * #39. AppleScript clusters a C0 control with a following combining mark into ONE character
+   * (`id of` -> {1, 769}), so #33's integer guard sent the whole cluster down the passthrough
+   * branch and a raw control byte reached the JSON string.
    *
-   * AppleScript clusters a C0 control with a following combining mark into one character
-   * (`id of` -> {1, 769}), so the guard added in #33 sends the whole cluster down the passthrough
-   * branch and a raw U+0001 reaches the JSON string.
+   * These were `it.fails` while the defect stood. They are ordinary assertions now.
    */
   describe("#39 — a control character leading a grapheme cluster", () => {
-    it.fails("should escape the control and keep the combining mark", () => {
+    it("escapes the control and keeps the combining mark", () => {
       expect(escape(codePoints(0x01, 0x0301))).toBe("\\u0001\u0301");
     });
 
-    it("currently emits the raw control character, which is invalid JSON", () => {
+    it("emits no raw control character, so the result parses as JSON", () => {
       const value = escape(codePoints(0x01, 0x0301));
-      expect(value).toContain("\u0001");
-      expect(() => JSON.parse(`{"v":"${value}"}`)).toThrow();
+      expect(value).not.toContain("\u0001");
+      expect(JSON.parse(`{"v":"${value}"}`)).toEqual({ v: "\u0001\u0301" });
+    });
+
+    // The general form, since the cluster need not lead with the control.
+    it("judges every code point of a cluster, not only the first", () => {
+      expect(escape(codePoints(0x65, 0x0301, 0x01))).toBe("e\u0301\\u0001");
     });
   });
 });

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -93,15 +93,19 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
   });
 
   /**
-   * #39. AppleScript clusters a C0 control with a following combining mark into ONE character
-   * (`id of` -> {1, 769}), so #33's integer guard sent the whole cluster down the passthrough
-   * branch and a raw control byte reached the JSON string.
+   * #39, and the class it belongs to.
+   *
+   * The delimiter phases at the top of the handler are cluster-blind: `text items of` does not
+   * split on a character that sits inside a grapheme cluster. So anything JSON requires escaping
+   * can still be raw when the per-character loop is reached — but only inside a cluster.
    *
    * These were `it.fails` while the defect stood. They are ordinary assertions now.
    */
-  describe("#39 — a control character leading a grapheme cluster", () => {
-    it("escapes the control and keeps the combining mark", () => {
+  describe("#39 — characters JSON must escape, hidden inside a grapheme cluster", () => {
+    it("escapes a control code point wherever it sits in the cluster", () => {
       expect(escape(codePoints(0x01, 0x0301))).toBe("\\u0001\u0301");
+      // Not only when it leads: the loop judges every code point.
+      expect(escape(codePoints(0x65, 0x0301, 0x01))).toBe("e\u0301\\u0001");
     });
 
     it("emits no raw control character, so the result parses as JSON", () => {
@@ -110,9 +114,42 @@ describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
       expect(JSON.parse(`{"v":"${value}"}`)).toEqual({ v: "\u0001\u0301" });
     });
 
-    // The general form, since the cluster need not lead with the control.
-    it("judges every code point of a cluster, not only the first", () => {
-      expect(escape(codePoints(0x65, 0x0301, 0x01))).toBe("e\u0301\\u0001");
+    /**
+     * Found by the supervisor pass, and it is the same defect one column over: a quote or
+     * backslash clustered with a combining mark reached the output raw, because the loop's only
+     * judgment was the control range.
+     */
+    it("escapes a quote and a backslash clustered with a combining mark", () => {
+      expect(escape(codePoints(0x22, 0x0301))).toBe('\\"\u0301');
+      expect(escape(codePoints(0x5c, 0x0301))).toBe("\\\\\u0301");
+    });
+
+    /**
+     * The guard on the fix for the line above. By the time the loop runs, the delimiter phases
+     * have already turned a bare quote into `\"` — two single-code-point characters. Escaping 34
+     * and 92 unconditionally would re-escape that half into `\\"`, breaking every quoted string.
+     * The escaping is therefore confined to the cluster branch, and this pins it.
+     */
+    it("does not double-escape a quote or backslash the delimiter phases already handled", () => {
+      expect(escape(codePoints(0x22))).toBe('\\"');
+      expect(escape(codePoints(0x5c))).toBe("\\\\");
+      expect(escape('"say \\"hi\\" \\\\ done"')).toBe('say \\"hi\\" \\\\ done');
+    });
+
+    /**
+     * Named controls are handled by their own delimiter phases, which are equally cluster-blind —
+     * so inside a cluster they fall through to the C0 loop and come out as \u00XX rather than \t.
+     * Both are valid JSON. Pinned because a future "tab is already handled above" tidy-up would
+     * regress this invisibly.
+     */
+    it.each([
+      ["tab", 0x09, "\\u0009"],
+      ["newline", 0x0a, "\\u000a"],
+      ["carriage return", 0x0d, "\\u000d"],
+    ])("escapes a %s clustered with a combining mark", (_name, point, expected) => {
+      const value = escape(codePoints(point as number, 0x0301));
+      expect(value).toBe(`${expected}\u0301`);
+      expect(() => JSON.parse(`{"v":"${value}"}`)).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Closes #39.

## What was wrong, and what turned out to be wrong underneath it

`escapeForJson` escaped its named characters with five text-item-delimiter passes, then swept the remainder character by character. #39 reported that a C0 control clustered with a combining mark slipped through and produced invalid JSON.

Two attempts at a narrow fix each broke something else, and the reason is the same both times: **`text items of` has no single behaviour to reason from.** Measured on this handler's own inputs:

| input | `text items` behaviour |
|---|---|
| `\` + U+0301 (combining mark) | **1 item** — blind, does not see inside |
| `\` + U+200D (ZWJ) + `A` | **2 items** — sees inside, matches the backslash, orphans the ZWJ |
| `"` + U+200C (ZWNJ) + `A` | **1 item** — refuses to match a bare, unclustered quote |

Whether a phase saw a character depended on which extender followed it. #33 fixed the symptom for combining marks. This PR's first version judged code points inside clusters — and double-escaped the ZWJ case, because the phase had already inserted a backslash that then re-clustered. `"`+ZWJ and `\`+ZWJ were **valid on main and broken by that fix**.

That is exactly the critique this PR makes of #33 — a fix reasoned from one case and generalised — turned on its own central comment, which claimed the phases are "cluster-blind".

## The fix

`id of theString` returns the string's code points, flat: no clustering, no collation, no matching. Every code point is judged once, on its own, and nothing earlier in the handler can have altered it.

The delimiter phases are deleted. The cases that were special have nothing left to be special about.

## What that closes

- The six input classes this PR already fixed, still fixed
- The three ZWJ cases this PR had **broken**, correct again
- `"` + ZWNJ, which was broken on `main` *and* on this branch's previous head — it came free rather than being aimed at, which is the sign the shape was wrong rather than the cases hard
- Empty string and single-character input, whose `id of` is an empty list and a bare integer respectively, both pinned

## Demonstrated, not argued

The new pins were run against every prior handler:

| handler | result |
|---|---|
| `main` (`f3a6d61`) | **7 failures** — combining-mark cases and ZWNJ (ZWJ passes, as expected) |
| this branch's previous head (`504d202`) | **7 failures** — including all three ZWJ cases, the regression |
| this head | **30 passed** |

## Verify

```
build=0  test=0  audit=0
Test Files  25 passed (25)
     Tests  477 passed (477)
100% statements / branches / functions / lines
```

Thirty of those execute against real `osascript`, on macOS only — see #40.

## Incidentally faster

20,000 characters in **5.69s**, against the old shape's 10.18s: one pass replacing five phases plus a per-character sweep. Still quadratic, so **#42 stands** with better constants — and its O(n) claim is gone along with the phases it described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6H7LRC6h2mSHH3yP2srH9
