### PR TITLE
docs(changelog): record 1.3.2, and backfill the missing 1.3.1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `npm audit` on every pull request (#36).
 - The repository is governed by its own Portulan workspace at `.portulan/` (#29).
 
+### Thanks
+
+- [@dessyd](https://github.com/dessyd) reported the escaping bug and sent the fix in #33. It was a
+  real one and it was found from outside: `escapeForJson` had no executable test coverage at all,
+  because the bridge is mocked in every other test, so nothing here could have caught it. The
+  diagnosis in that pull request was exact — AppleScript returns a list of code points for a
+  multi-code-point grapheme cluster — and it is what the rest of this release was built on. Thank
+  you for taking the time.
+
 ## [1.3.1] - 2026-08-05
 
 Recorded after the fact — this entry was missing, and is written from the commits the tag carries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-08-20
+
+### Fixed
+
+- Reading a mailbox no longer fails when a message subject or sender contains emoji or accented
+  text. AppleScript returns a *list* of code points rather than an integer for a multi-code-point
+  grapheme cluster — an emoji with a variation selector (`❤️`), a ZWJ sequence (`👨‍👩‍👧`), or a
+  decomposed accent — and comparing that list against the control-character range raised
+  `Can't make {…} into type number, date or text (-1700)`. A single such message made
+  `list_messages` fail outright, not just that message, because `escapeForJson` is applied to every
+  subject and sender. Reported and first fixed by [@dessyd](https://github.com/dessyd) in #33.
+- Characters that JSON requires escaping no longer reach the output raw when they sit next to a
+  combining mark or a zero-width joiner. A control character, quote or backslash in that position
+  was emitted unescaped, producing a JSON string no parser accepts — the tool then failed with a
+  parse error naming neither the message nor the cause (#41).
+
+### Changed
+
+- `escapeForJson` now escapes by code point in a single pass, rather than by five text-item-delimiter
+  passes followed by a per-character sweep. The delimiter approach had no consistent behaviour to
+  reason from: measured, it was blind to a backslash followed by a combining mark, split a cluster
+  containing one followed by a zero-width joiner, and refused to match a bare quote followed by a
+  zero-width non-joiner. Also about 1.8× faster on long strings (#41).
+
+### Internal
+
+- First tests that execute AppleScript for real, through `osascript`. They cover the escaping
+  handler across precomposed, decomposed, variation-selector, astral and ZWJ text, and they **skip
+  off macOS, which includes CI** — there is no `osascript` on the Linux runner (#40).
+- Merges now wait for a Copilot review round on the exact commit being merged, branch drift behind
+  `main` is bounded at five commits, a held fork pull request says so instead of showing nothing,
+  and the aggregate status check `ci-ok` was renamed `verify` (#37).
+- Dependency and action-pin sweep, clearing a high-severity `nanoid` advisory that was failing
+  `npm audit` on every pull request (#36).
+- The repository is governed by its own Portulan workspace at `.portulan/` (#29).
+
+## [1.3.1] - 2026-08-05
+
+Recorded after the fact — this entry was missing, and is written from the commits the tag carries.
+
+### Fixed
+
+- Publishing over OIDC no longer fails on an empty `_authToken`. `setup-node` writes one into
+  `.npmrc`, which disabled trusted publishing and surfaced as `E404` — a message that reads as a
+  missing package rather than an authentication failure (#23).
+- The release now asserts the version it committed rather than the working tree, which a release
+  rewrites before its checks run (#28).
+
+### Changed
+
+- The release is one workflow run, with the tag as the source of truth for what shipped. The
+  version is computed at release time from the conventional commits since the last tag, and the tag
+  is pushed only after the registry confirms the publish — so a failed publish cannot leave a tag
+  pointing at a version that does not exist (#24, #27).
+
+### Documentation
+
+- README registers the server via `npx` rather than a frozen local build path (#25).
+
 ## [1.3.0] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - First tests that execute AppleScript for real, through `osascript`. They cover the escaping
-  handler across precomposed, decomposed, variation-selector, astral and ZWJ text, and they **skip
-  off macOS, which includes CI** — there is no `osascript` on the Linux runner (#40).
+  handler across precomposed, decomposed, variation-selector, astral and ZWJ text. They **run only
+  on macOS and are skipped everywhere else, including CI** — there is no `osascript` on the Linux
+  runner (#40).
 - Merges now wait for a Copilot review round on the exact commit being merged, branch drift behind
   `main` is bounded at five commits, a held fork pull request says so instead of showing nothing,
   and the aggregate status check `ci-ok` was renamed `verify` (#37).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ checks that the required status check `verify` is one a workflow here actually r
   `src/**/*.ts` only. Because the bridge is mocked, the AppleScript templates are text handed to a
   mock rather than code that runs — which is how a handler that threw on any emoji subject shipped
   unexercised, found by an outside contributor (#33) rather than by the suite. `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
-  `osascript` for real, and **skips off macOS, which includes CI**. So those assertions run on a
+  `osascript` for real. It **runs only on macOS and is skipped everywhere else, including CI**, so
+  those assertions run on a
   maintainer's machine and never in the merge gate. Run `npm run test:coverage` locally before
   touching anything under `src/**/*.applescript`; the runner cannot do it for you.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,12 @@ checks that the required status check `verify` is one a workflow here actually r
 - **The `.applescript` files are the exception, and it is a real one.** That 100% covers
   `src/**/*.ts` only. Because the bridge is mocked, the AppleScript templates are text handed to a
   mock rather than code that runs — which is how a handler that threw on any emoji subject shipped
-  unexercised, found by an outside contributor (#33) rather than by the suite. `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
+  unexercised, found by an outside contributor (#33) rather than by the suite.
+  `tests/bridge/escape-for-json.applescript.test.ts` executes the escaping handler through
   `osascript` for real. It **runs only on macOS and is skipped everywhere else, including CI**, so
-  those assertions run on a
-  maintainer's machine and never in the merge gate. Run `npm run test:coverage` locally before
-  touching anything under `src/**/*.applescript`; the runner cannot do it for you.
+  those assertions run on a maintainer's machine and never in the merge gate. Run
+  `npm run test:coverage` locally before touching anything under `src/**/*.applescript`; the runner
+  cannot do it for you.
 
 ## Architecture
 

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -9,10 +9,10 @@ const escape = (expression: string) => runHandler(HANDLER, `escapeForJson(${expr
  * The first tests in this repository that execute AppleScript.
  *
  * Run only on macOS; skipped everywhere else, including CI, because `osascript` does not exist on
- * the Linux runner. That is a
- * real limit and not a soft one: these assertions run where the code runs, on a maintainer's
- * machine, and never in the merge gate. They are still worth having, because the alternative was a
- * handler with no executable coverage at all, which is how #33 shipped.
+ * the Linux runner. That is a real limit and not a soft one: these assertions run where the code
+ * runs, on a maintainer's machine, and never in the merge gate. They are still worth having,
+ * because the alternative was a handler with no executable coverage at all, which is how #33
+ * shipped.
  */
 describe.skipIf(!onMacOS)("escapeForJson, executed", () => {
   describe("text that needs no escaping survives unchanged", () => {

--- a/tests/bridge/escape-for-json.applescript.test.ts
+++ b/tests/bridge/escape-for-json.applescript.test.ts
@@ -8,7 +8,8 @@ const escape = (expression: string) => runHandler(HANDLER, `escapeForJson(${expr
 /**
  * The first tests in this repository that execute AppleScript.
  *
- * Skipped off macOS, which includes CI — `osascript` does not exist on the Linux runner. That is a
+ * Run only on macOS; skipped everywhere else, including CI, because `osascript` does not exist on
+ * the Linux runner. That is a
  * real limit and not a soft one: these assertions run where the code runs, on a maintainer's
  * machine, and never in the merge gate. They are still worth having, because the alternative was a
  * handler with no executable coverage at all, which is how #33 shipped.


### PR DESCRIPTION
`CHANGELOG.md`'s newest entry was **1.3.0** while npm carries **1.3.1** — already a release behind, before 1.3.2 is cut.

## Why it drifted, so it does not recur

`release-notes.mjs` states the model directly: the release workflow **never commits to `main`**, so it builds the GitHub release body from git and leaves `CHANGELOG.md` to ordinary pull requests.

A changelog entry can therefore only be written **before the tag exists**. Miss that window and the file is permanently one release behind — which is exactly what happened to 1.3.1. So both entries land here, ahead of the tag.

## 1.3.2

Leads with what a user of this server notices: **a mailbox containing one emoji subject no longer fails to list.** `escapeForJson` is applied to every subject and sender, so a single message with a variation-selector emoji, a ZWJ sequence, or a decomposed accent made `list_messages` throw outright — not just that message.

Credit to @dessyd, who reported and first fixed it in #33.

The entry now carries a **Thanks** section saying so properly, rather than only an inline attribution. Note it is written there as a markdown link rather than a bare `@dessyd`: GitHub does not autolink mentions inside repository files, only in issues, pull requests and comments — so the link form is what actually renders as a clickable @dessyd on the file page. The real mention is here, where it notifies.

The escaping rewrite and the CI work sit under **Changed** and **Internal**, where someone scanning for behaviour changes will not trip over them.

## 1.3.1 — backfilled

Written from the commits the tag carries, and it **says so in the entry**: a record made after the fact is not a contemporaneous one, and a reader should be able to tell which they are looking at.

Covers the OIDC `_authToken` fix (#23), the committed-version assertion (#28), the one-run release with the tag as source of truth (#24, #27), and the npx registration docs (#25).

## One thing to check before tagging

The **1.3.2 heading is dated 2026-08-20**, assuming the release is cut today. If it slips, that date needs correcting before the tag — the file cannot check itself, because this repository deliberately keeps no version in the tree.

## Verify

```
build=0  test=0  audit=0
Tests  477 passed (477)
```

Documentation only; no source or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6H7LRC6h2mSHH3yP2srH9

