### PR TITLE
chore(portulan): compile the gate map into enforcement, and measure the floor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@ coverage/
 .DS_Store
 .env
 .env.*
+
+# Portulan — compiled enforcement. Machine-specific: the hook command is an absolute
+# path into this machine's plugin cache, pinned to a plugin version, because the runner
+# is not under this project. Committing it would put a path in the tree that is wrong on
+# every other machine, and a hook whose file is missing FAILS OPEN. Regenerate with
+# `portulan compile`. See .portulan/gate-map.md, "The policy, and what compiles it".
+.claude/settings.json
+
+# Worktrees live under .claude/ and are whole checkouts; never commit one.
+.claude/worktrees/

--- a/.portulan/compile/github-ruleset.json
+++ b/.portulan/compile/github-ruleset.json
@@ -1,0 +1,56 @@
+{
+  "name": "portulan floor — main (generated from .portulan/gates.json)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "verify",
+            "integration_id": 15368
+          },
+          {
+            "context": "copilot-reviewed"
+          },
+          {
+            "context": "branch-freshness",
+            "integration_id": 15368
+          },
+          {
+            "context": "analyze",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.portulan/gate-map.md
+++ b/.portulan/gate-map.md
@@ -8,12 +8,17 @@ Which actions sit in which autonomy tier for this repository. The tier vocabular
 (`core/operating/autonomy.md`); which concrete action lands in which tier is this workspace's answer,
 which is the split the cascade exists to keep.
 
-| Tier | Actions |
+| Tier | Actions, each naming the policy rule that states it |
 |---|---|
-| **Auto** | read anything · run the verify recipe · push a working branch · open or update a draft |
-| **Propose** | open a pull request · request a review · reply to review feedback |
-| **Gated** | merge · run **Release** with `mode: publish` · push a tag · `npm publish` by hand · bare `--force` · branch delete · change branch protection |
+| **Auto** | read anything (`read-anything-in-the-repository`) · edit on a working branch (`edit-on-a-working-branch`) · commit to one (`commit-to-a-working-branch`) · push one (`push-a-working-branch`) · open or update a draft (`open-or-update-a-draft`) · run the verify recipe (`run-the-verify-recipe`) |
+| **Propose** | open a pull request (`open-a-pull-request`) · request a review (`request-a-review`) · reply to review feedback (`reply-to-review-feedback`) |
+| **Gated** | merge (`merge-a-pull-request`) · run **Release** with `mode: publish` (`publish-a-release`) · push a tag (`push-a-tag`) · `npm publish` by hand (`publish-to-npm-by-hand`) · bare `--force` (`force-push-without-a-lease`) · branch delete (`delete-a-remote-branch`) · change branch protection (`change-branch-protection`) |
 | **Prohibited** | — |
+
+**Two rows in Auto are new words for an old rule, not a widening.** `edit-on-a-working-branch` and
+`commit-to-a-working-branch` were implied by *push a working branch* and never written down — you
+cannot push what you have not committed. Naming them was forced by `gates.json`, which has to state a
+tier for an action or have none, and an unstated Auto reads identically to an oversight.
 
 **Publishing is Gated, and the tag with it.** The release workflow pushes the tag itself, after the
 registry confirms; a human pushing one by hand routes around the ordering that stops a tag outliving
@@ -31,6 +36,71 @@ can use in an emergency. An earlier draft of this table put it in Prohibited, wh
 acceptable. An empty row is the honest answer; reaching for the tier because an action is merely
 severe is how the tier stops meaning anything.
 
+## The policy, and what compiles it
+
+This map is the argument; [`gates.json`](gates.json) beside it is the policy. Two files state one
+thing, which is a real defect and is contained rather than denied: **every rule carries an `id`, this
+map cites every one of them in a code span, and where the two disagree the policy wins** — it is the
+one that compiles. Sixteen rules, sixteen citations in the table above.
+
+`portulan compile` turns the Gated rows into host enforcement. Six of them reach a matcher and become
+`ask` permissions; the rest are reported rather than emitted, and the reporting is the point:
+
+- **`change-branch-protection` compiles to nothing, and is declared anyway.** There is no matchable
+  prefix — it is `gh api` against a rulesets endpoint, or the web UI. `gh api` is also how a read-only
+  query is made, so gating that prefix would gate reads and train the approver to click through on
+  sight, which buys less than the honest gap costs. It stays a habit, and it is visible as one.
+- **`auto` and `propose` compile to nothing by design.** The compiler emits restriction only. Propose
+  is enforced by the platform floor below; Auto is unattended by policy, not by permission.
+
+**The floor is declared, and the export diverges from it in exactly one parameter.** `floor` in the
+policy states this repository's live platform floor, and it was written from the live settings rather
+than from memory — `refs/heads/main`, the four required checks with their app pins, zero required
+approving reviews, conversation resolution on. [`compile/github-ruleset.json`](compile/github-ruleset.json)
+is generated from it and matches the live configuration on every parameter but one:
+
+| | live on `main` | generated export |
+|---|---|---|
+| `strict_required_status_checks_policy` | **`false`** | **`true`** |
+
+The compiler hard-codes `true` and deliberately refuses to make it declarable, on the reasoning that a
+declarable `strict` would let a policy edit undo a ruling with no diff anyone would read as one. That
+is sound upstream and it is the opposite of the ruling recorded below, where `strict` was turned off
+because it forced a rebase whenever `main` moved and every rebase costs a review round.
+
+**So the export must not be imported as-is.** Importing it would silently re-enable `strict` and
+reinstate the cost `branch-freshness` was built to remove. The divergence is pinned by
+`tests/portulan/gate-policy.test.ts` rather than left to this paragraph: if the exported artifact ever
+stops saying `true`, or this map ever stops saying the live floor is `false`, the suite fails. A
+contradiction that is measured every run is a different thing from one nobody noticed.
+
+Two further gaps the export carries, both reported by the compiler and neither hidden here:
+`non_fast_forward` is **stricter** than the policy — it blocks every force-push including
+`git push --force-with-lease`, which this map classifies Auto, because a ref rule cannot read a
+command's flags. And `merge-a-pull-request` compiles to nothing on this backend: with zero required
+approving reviews the floor constrains a merge but does not require a human's yes, which is what Gated
+means. That gate lives in the Claude Code artifact and in habit, not in the ruleset.
+
+**The Claude Code artifact is not committed.** The hook command is an absolute path into the
+maintainer's plugin cache, pinned to a plugin version, because the runner does not live under this
+project. On any other machine that path does not resolve, and **a missing hook fails open** — so
+committing it would ship a file that looks like enforcement and is not. `.claude/settings.json` is
+git-ignored and regenerated with `portulan compile`. The ruleset artifact beside it has no such
+problem and is committed. Installing the CLI as a dev dependency would make the hook path
+project-relative and that artifact portable too; that is a dependency decision the maintainer has not
+taken.
+
+**The compiled artifact is not committed.** The hook command is an absolute path into the maintainer's
+plugin cache, pinned to a plugin version, because the runner does not live under this project. On any
+other machine that path does not resolve, and **a missing hook fails open** — so committing it would
+ship a file that looks like enforcement and is not. `.claude/settings.json` is git-ignored and
+regenerated with `portulan compile`. Installing the CLI as a dev dependency would make the path
+project-relative and the artifact portable; that is a dependency decision the maintainer has not taken.
+
+**Retire when:** the compiled artifact becomes portable and committable, at which point it is the
+authority and this table becomes its rationale rather than its statement. Until then the policy
+compiles on one machine and this map is what every other reader has.
+
 ## The platform floor
 
 | Setting | Value |
@@ -38,6 +108,13 @@ severe is how the tier stops meaning anything.
 | Required status checks | `verify`, `copilot-reviewed`, `branch-freshness`, `analyze` |
 | Branch protection | `main` — pull request required, no force-push, no deletion, `enforce_admins`, conversation resolution required, **not** strict |
 | Required approvals | 0 — GitHub forbids self-approval, and any higher number deadlocks a sole maintainer |
+
+**`copilot-reviewed` is the one required check with no app pin.** Measured live on 2026-08-22:
+`verify`, `branch-freshness` and `analyze` each carry `app_id 15368` (GitHub Actions), and
+`copilot-reviewed` carries `null`. A context with no pin is satisfiable by **any** app reporting that
+name, so the check that exists to stop a stale verdict is itself the least constrained of the four.
+The policy declares it unpinned because that is what is live, not because it should stay that way;
+pinning it is a branch-protection change, which is Gated (`change-branch-protection`).
 
 The `copilot-reviewed` check and the `copilot auto-review on pull requests` ruleset are a pair: the
 check waits for a round, the ruleset is what requests one. The payload is kept at
@@ -63,5 +140,6 @@ gating the merge every unrelated commit to `main` then cost a full round on a br
 had not changed. `branch-freshness` replaces it with a bound that has a number in it: drift is
 allowed up to `DEFAULT_LIMIT` commits (5), which the tests pin.
 
-**Retire when:** this repository compiles a `gates.json`, at which point the compiled artifact is the
-authority and this table becomes its rationale rather than its statement.
+**Retire when:** superseded by the retirement condition in *The policy, and what compiles it* above.
+The original condition — *this repository compiles a `gates.json`* — was met on 2026-08-22 and was not
+the finish line it read as: the policy compiles, and the artifact it produces is machine-local.

--- a/.portulan/gate-map.md
+++ b/.portulan/gate-map.md
@@ -90,13 +90,6 @@ problem and is committed. Installing the CLI as a dev dependency would make the 
 project-relative and that artifact portable too; that is a dependency decision the maintainer has not
 taken.
 
-**The compiled artifact is not committed.** The hook command is an absolute path into the maintainer's
-plugin cache, pinned to a plugin version, because the runner does not live under this project. On any
-other machine that path does not resolve, and **a missing hook fails open** — so committing it would
-ship a file that looks like enforcement and is not. `.claude/settings.json` is git-ignored and
-regenerated with `portulan compile`. Installing the CLI as a dev dependency would make the path
-project-relative and the artifact portable; that is a dependency decision the maintainer has not taken.
-
 **Retire when:** the compiled artifact becomes portable and committable, at which point it is the
 authority and this table becomes its rationale rather than its statement. Until then the policy
 compiles on one machine and this map is what every other reader has.

--- a/.portulan/gates.json
+++ b/.portulan/gates.json
@@ -1,0 +1,122 @@
+{
+  "portulan": {
+    "spec": "2.2"
+  },
+
+  "why": "gate-map.md",
+
+  "floor": {
+    "branch": "main",
+    "checks": [
+      { "context": "verify", "integration_id": 15368 },
+      { "context": "copilot-reviewed" },
+      { "context": "branch-freshness", "integration_id": 15368 },
+      { "context": "analyze", "integration_id": 15368 }
+    ],
+    "reviews": 0,
+    "resolve_conversations": true
+  },
+
+  "rules": [
+    {
+      "id": "merge-a-pull-request",
+      "tier": "gated",
+      "action": { "shell": "gh pr merge" },
+      "reason": "An agent never decides for itself that a change is ready to land. A commit enters this repository's record here, not at the push. Two preconditions the maintainer's approval does not waive: the required checks are green on the CURRENT head, and the review verdict post-dates that head — `copilot-reviewed` enforces the second, after PR #25 merged on a verdict that predated its tree."
+    },
+    {
+      "id": "publish-a-release",
+      "tier": "gated",
+      "action": { "shell": "gh workflow run" },
+      "reason": "Running the Release workflow with `mode: publish` publishes to npm, pushes the tag and cuts the GitHub release in one irreversible run. `mode: dry-run` is the default and does everything except the irreversible parts, but the two spellings share one command, so the gate is on the command and the mode is what the human is approving. Matched at `gh workflow run` rather than at the mode, because a matcher that read the mode would let a typo through as Auto."
+    },
+    {
+      "id": "push-a-tag",
+      "tier": "gated",
+      "action": { "shell": "git push --tags" },
+      "reason": "The release workflow pushes the tag itself, after the registry confirms the version exists. A human pushing one by hand routes around the ordering that stops a tag outliving a failed publish — the state v1.3.0 reached and the reason `prefer the reversible thing last` is a principle here. NAMED GAP: this matches `--tags` only. `git push origin v1.3.3` pushes a tag by a spelling no prefix here reaches, and `git push` is Auto, so that spelling compiles to nothing. The gap is named rather than papered over with a matcher that would gate every push."
+    },
+    {
+      "id": "publish-to-npm-by-hand",
+      "tier": "gated",
+      "action": { "shell": "npm publish" },
+      "reason": "Gated, not Prohibited, and the distinction is deliberate. A hand publish produces a release with NO provenance attestation, permanently — attestations attach at publish time and cannot be added afterwards, which is why 1.3.0 has none and never will. That is a real cost and the reason it needs approval. But if the OIDC pipeline is broken and a security fix has to ship, it is the right call, and a tier nobody can approve is a tier nobody can use in an emergency."
+    },
+    {
+      "id": "force-push-without-a-lease",
+      "tier": "gated",
+      "action": { "shell": "git push --force" },
+      "reason": "A bare `--force` can silently discard commits that arrived since you last fetched, and that is the one part of pushing which is not recoverable inside a working copy. Use `--force-with-lease`, which is Auto: the lease refuses the push if the remote moved. The matcher is token-aware, so this rule does not catch `--force-with-lease`."
+    },
+    {
+      "id": "delete-a-remote-branch",
+      "tier": "gated",
+      "action": { "shell": "git push --delete" },
+      "reason": "Deleting a branch on a shared remote destroys a ref rather than adding one, which is the single push spelling that stays Gated while ordinary pushes are Auto. `main` is protected against deletion by the platform floor regardless, which is a rail rather than a rule."
+    },
+    {
+      "id": "change-branch-protection",
+      "tier": "gated",
+      "action": {
+        "none": "No matchable prefix. Branch protection here is changed through `gh api` against a rulesets or protection endpoint, or in the web UI, which no permission rule reaches. `gh api` is also how read-only queries are made — `gh api repos/{owner}/{repo}/compare/...` is part of checking a head is not behind — so gating the prefix would gate reads and train the human to approve on sight, which is worse than the honest gap. Stated as a rule with no surface so the tier is visible rather than implied."
+      },
+      "reason": "Changing branch protection changes what every future merge is allowed to do, including the required checks and the review gate this repository relies on. It is the one settings change that can retroactively weaken every gate beneath it."
+    },
+
+    {
+      "id": "open-a-pull-request",
+      "tier": "propose",
+      "action": { "shell": "gh pr create" },
+      "reason": "Opening a pull request is reversible but consequential: it requests a review round and starts the checks. The gate is the maintainer's decision to merge, not the keystroke that opens the request. A draft is Auto — `open-or-update-a-draft` is the narrower prefix and is matched first."
+    },
+    {
+      "id": "request-a-review",
+      "tier": "propose",
+      "action": { "shell": "gh pr edit --add-reviewer" },
+      "reason": "Requesting a review spends a Copilot round and, on a stacked pull request against a non-default branch, may draw nobody at all — issue #44. Proposing rather than doing it unattended keeps the budget visible."
+    },
+    {
+      "id": "reply-to-review-feedback",
+      "tier": "propose",
+      "action": { "shell": "gh pr comment" },
+      "reason": "A reply on a pull request is outward-facing text under the maintainer's name. Reversible, so not Gated; visible to a reviewer, so not unattended."
+    },
+
+    {
+      "id": "read-anything-in-the-repository",
+      "tier": "auto",
+      "action": { "read": "./" },
+      "reason": "Reading anything in the repository, including git history, is unattended."
+    },
+    {
+      "id": "edit-on-a-working-branch",
+      "tier": "auto",
+      "action": { "write": "./" },
+      "reason": "Creating and editing files on a working branch, in a worktree, is unattended. What makes this safe is the merge gate, not the edit itself — `main` is protected with `enforce_admins`, so no edit here reaches the record without passing through `merge-a-pull-request`."
+    },
+    {
+      "id": "commit-to-a-working-branch",
+      "tier": "auto",
+      "action": { "shell": "git commit" },
+      "reason": "Committing to a working branch is unattended. Committing to `main` is refused by the platform floor, which is a rail rather than a rule."
+    },
+    {
+      "id": "push-a-working-branch",
+      "tier": "auto",
+      "action": { "shell": "git push" },
+      "reason": "Pushing a working branch is unattended: it is visible but is not yet a claim on the repository, and the guarantee lives at the merge. The three Gated spellings — `--tags`, `--force`, `--delete` — are narrower prefixes and are matched first."
+    },
+    {
+      "id": "open-or-update-a-draft",
+      "tier": "auto",
+      "action": { "shell": "gh pr create --draft" },
+      "reason": "A draft pull request draws no review round and makes no claim that a change is ready. Opening or updating one is unattended; promoting it out of draft is `open-a-pull-request`."
+    },
+    {
+      "id": "run-the-verify-recipe",
+      "tier": "auto",
+      "action": { "shell": "npm run" },
+      "reason": "The default recipe is `npm run build && npm run test:coverage && npm audit --audit-level=high`. Every script in this package is local and reversible — build, copy-scripts, test, test:coverage, test:watch, dev — and the one that touches a registry, `prepublishOnly`, runs only as part of `npm publish`, which is Gated on its own prefix. Running the recipe is not merely permitted here, it is condition 1 of the definition of done."
+    }
+  ]
+}

--- a/.portulan/handoffs/2026-08-22-a-gate-policy-that-compiles-on-one-machine.md
+++ b/.portulan/handoffs/2026-08-22-a-gate-policy-that-compiles-on-one-machine.md
@@ -4,7 +4,7 @@
 reads. `.portulan/gates.json` now exists — 16 rules and a floor, spec 2.2 — and `portulan compile`
 **exits 0**, emitting six `ask` permissions, two hooks, and an importable GitHub ruleset. `doctor` GREEN, agent legibility **2 of 5 → 3 of 5**.
 Verify green: **491 tests across 26 files** (477 + 14 new), 100% statements/branches/functions/lines on
-`src/`, 0 vulnerabilities. Committed to a working branch and opened as a pull request.
+`src/`, 0 vulnerabilities. Committed to a working branch and opened as [#46](https://github.com/marius-cetanas/macos-mail-mcp/pull/46).
 
 ## What was added, and the one thing that was deliberately not
 
@@ -36,8 +36,9 @@ branch-protection change and therefore Gated.
   scaffold writes `"portulan": { "gates": "1.0" }`, the compiler validates `portulan.spec` against
   `{2.1, 2.2}`, so a freshly scaffolded policy dies on `gate-policy spec undefined` (exit 2). The
   scaffold's `floor` shape disagrees too — `require_pull_request` / `block_force_push` against the
-  compiler's `reviews` / `resolve_conversations`. Worth filing against portulan 0.1.2. The policy here
-  was written against the compiler's actual contract, not the scaffold.
+  compiler's `reviews` / `resolve_conversations`. Filed upstream as
+  [portulan#329](https://github.com/sleepy-panda-srl/portulan/issues/329) — do not re-file it. The
+  policy here was written against the compiler's actual contract, not the scaffold.
 - **The compiled artifact is pinned to one machine and is therefore not committed.** The runner is not
   under this project, so the hook command is an absolute path into the plugin cache including the
   version — `…/portulan/0.1.2/cli/gate.mjs`. On any other machine that path does not resolve, and **a

--- a/.portulan/handoffs/2026-08-22-a-gate-policy-that-compiles-on-one-machine.md
+++ b/.portulan/handoffs/2026-08-22-a-gate-policy-that-compiles-on-one-machine.md
@@ -1,0 +1,65 @@
+# Handoff — a gate policy that compiles, an artifact that cannot be committed
+
+**State.** The workspace was already GREEN and already curated; what it lacked was the half a machine
+reads. `.portulan/gates.json` now exists — 16 rules and a floor, spec 2.2 — and `portulan compile`
+**exits 0**, emitting six `ask` permissions, two hooks, and an importable GitHub ruleset. `doctor` GREEN, agent legibility **2 of 5 → 3 of 5**.
+Verify green: **491 tests across 26 files** (477 + 14 new), 100% statements/branches/functions/lines on
+`src/`, 0 vulnerabilities. Committed to a working branch and opened as a pull request.
+
+## What was added, and the one thing that was deliberately not
+
+Six Gated rows now compile to real matchers: `gh pr merge`, `gh workflow run`, `git push --tags`,
+`npm publish`, `git push --force`, `git push --delete`. Two rules are declared and compile to nothing,
+which is reported rather than hidden — `change-branch-protection` has no matchable prefix (`gh api` is
+also how read-only queries are made, so gating it would train the approver to click through), and the
+`auto`/`propose` tiers are not what a restriction-only compiler emits.
+
+**The floor is declared, and it was written from the live settings rather than from memory.** Fetched
+on 2026-08-22: `strict false`, four required checks, zero required approving reviews, conversation
+resolution on, `enforce_admins` on, force-push and deletion off. The gate map's account of the floor
+was accurate in every particular. The export
+[`compile/github-ruleset.json`](../compile/github-ruleset.json) matches it on every parameter but one —
+the compiler hard-codes `strict_required_status_checks_policy: true` and refuses to make it
+declarable, which is the exact inverse of this repository's ruling. **The export must therefore not be
+imported as-is**, and that divergence is pinned by a test rather than by a paragraph: flip the exported
+value and the suite goes red.
+
+**One live finding worth acting on.** `copilot-reviewed` is the only required check with no app pin —
+`verify`, `branch-freshness` and `analyze` all carry `app_id 15368`, it carries `null`. A context with
+no pin is satisfiable by any app reporting that name, so the check built to stop a stale verdict is the
+least constrained of the four. The policy declares it as it is, not as it should be; pinning it is a
+branch-protection change and therefore Gated.
+
+## Three findings, one of them upstream
+
+- **`portulan new gate-policy` emits a scaffold that `portulan compile` refuses.** Measured: the
+  scaffold writes `"portulan": { "gates": "1.0" }`, the compiler validates `portulan.spec` against
+  `{2.1, 2.2}`, so a freshly scaffolded policy dies on `gate-policy spec undefined` (exit 2). The
+  scaffold's `floor` shape disagrees too — `require_pull_request` / `block_force_push` against the
+  compiler's `reviews` / `resolve_conversations`. Worth filing against portulan 0.1.2. The policy here
+  was written against the compiler's actual contract, not the scaffold.
+- **The compiled artifact is pinned to one machine and is therefore not committed.** The runner is not
+  under this project, so the hook command is an absolute path into the plugin cache including the
+  version — `…/portulan/0.1.2/cli/gate.mjs`. On any other machine that path does not resolve, and **a
+  missing hook fails open**: it would look like enforcement and be nothing. `.claude/settings.json` is
+  git-ignored and regenerated with `portulan compile`. The consequence to hold onto is that **this
+  repository's gates are enforced on one laptop**, and every other reader has the prose.
+- **The prose/policy duplication is now a test, not a promise.** The Workspace Definition requires
+  membership to hold both ways between `gates.json` and `gate-map.md`. That was prose; it is now
+  `tests/portulan/gate-policy.test.ts`, which runs in CI. It was verified by mutation in both
+  directions — a dropped citation and a phantom one each turn it red — because a check that has never
+  failed has not been shown to work.
+
+## For the next session
+
+- **The pinning decision is the maintainer's and is still open.** `npm i -D @sleepy_panda_srl/portulan`
+  would make the hook path `${CLAUDE_PROJECT_DIR}`-relative, which makes the artifact portable,
+  committable, reviewable in a diff, and drift-checkable in CI. The cost is a dev dependency and its
+  audit surface on a published package. Until that is taken, do not commit `.claude/settings.json`.
+- **`compile --check` cannot go in the CI recipe** while the artifact is machine-specific: CI would
+  recompile with a different runner path and report drift that is not drift. It is a local check.
+- **Re-run `portulan compile` after any plugin upgrade.** The version is baked into the hook path, so
+  an upgrade silently unhooks the gate. This is the failure the compiler itself warns about, and it
+  fails open.
+- #42 (quadratic `escapeForJson`) and #44 (no Copilot round on a non-default-branch PR) remain open and
+  untouched by this session.

--- a/.portulan/workspace.json
+++ b/.portulan/workspace.json
@@ -17,6 +17,8 @@
     "handoffs": "handoffs/"
   },
 
+  "gates": "gates.json",
+
   "verify": {
     "default": "repo",
     "recipes": [

--- a/tests/portulan/gate-policy.test.ts
+++ b/tests/portulan/gate-policy.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+interface Rule {
+  id: string;
+  tier: string;
+  reason: string;
+  action: Record<string, string>;
+}
+
+interface Floor {
+  branch: string;
+  checks: { context: string; integration_id?: number }[];
+  reviews: number;
+  resolve_conversations: boolean;
+}
+
+const policy: { portulan: { spec: string }; why: string; rules: Rule[]; floor?: Floor } =
+  JSON.parse(read(".portulan/gates.json"));
+const map = read(".portulan/gate-map.md");
+const manifest = JSON.parse(read(".portulan/workspace.json"));
+
+/**
+ * `gates.json` and `gate-map.md` state one policy in two files — the JSON is what compiles,
+ * the Markdown is why. The Workspace Definition contains that duplication by requiring
+ * membership to hold BOTH ways: a rule nothing cites, or a citation backing no rule, fails.
+ * These tests are that requirement, which was prose until this change.
+ *
+ * Only the four tier rows are parsed. The platform-floor table below them also uses code
+ * spans, so sweeping the whole file would read `verify` and `enforce_admins` as rules that
+ * had gone missing — a false red, and a false red is what gets a check switched off.
+ */
+const TIERS = ["Auto", "Propose", "Gated", "Prohibited"] as const;
+
+const rowFor = (tier: string): string => {
+  const row = map.split("\n").find((l) => l.startsWith(`| **${tier}**`));
+  if (!row) throw new Error(`gate-map.md has no \`${tier}\` row in the tier table`);
+  return row;
+};
+
+/**
+ * A citation is a code span shaped like a rule id. `npm publish`, `mode: publish` and
+ * `--force` all appear as code spans in the same rows and none of them can match: the
+ * shape admits no spaces, no colons and no leading dash.
+ */
+const citedIn = (tier: string): string[] =>
+  [...rowFor(tier).matchAll(/`([a-z0-9]+(?:-[a-z0-9]+)*)`/g)].map((m) => m[1]);
+
+const cited = new Map<string, string>();
+for (const tier of TIERS) for (const id of citedIn(tier)) cited.set(id, tier.toLowerCase());
+
+describe("the gate policy and the gate map state one policy", () => {
+  it("cites every rule in the map, in the row for its own tier", () => {
+    for (const rule of policy.rules) {
+      expect(cited.get(rule.id), `rule \`${rule.id}\` is cited by no row in gate-map.md`).toBe(
+        rule.tier,
+      );
+    }
+  });
+
+  it("backs every citation in the map with a rule of that tier", () => {
+    const byId = new Map(policy.rules.map((r) => [r.id, r.tier]));
+    for (const [id, tier] of cited) {
+      expect(byId.get(id), `gate-map.md cites \`${id}\`, which no rule in gates.json declares`).toBe(
+        tier,
+      );
+    }
+  });
+
+  it("cites each rule exactly once, so a tier cannot be claimed twice", () => {
+    const all = TIERS.flatMap((t) => citedIn(t));
+    expect(all.length).toBe(new Set(all).size);
+    expect(all.length).toBe(policy.rules.length);
+  });
+});
+
+describe("the policy is well formed", () => {
+  it("gives every rule a unique id", () => {
+    const ids = policy.rules.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every rule a reason, because a gate with no sentence to show a human is not finished", () => {
+    for (const rule of policy.rules) expect(rule.reason.trim().length).toBeGreaterThan(0);
+  });
+
+  it("declares no prohibited rule, and the map's Prohibited row cites none", () => {
+    expect(policy.rules.filter((r) => r.tier === "prohibited")).toEqual([]);
+    expect(citedIn("Prohibited")).toEqual([]);
+  });
+});
+
+describe("the workspace wires the policy in", () => {
+  it("declares the policy on the top-level `gates` key, not in `slots`", () => {
+    expect(manifest.gates).toBe("gates.json");
+    expect(existsSync(join(ROOT, ".portulan", manifest.gates))).toBe(true);
+  });
+
+  it("keeps `slots.gates` pointed at the prose, which is the other question", () => {
+    expect(manifest.slots.gates).toBe("gate-map.md");
+  });
+
+  it("ignores the compiled artifact, which is machine-specific and fails open when stale", () => {
+    expect(read(".gitignore")).toContain(".claude/settings.json");
+  });
+});
+
+/**
+ * The floor compiles to an importable GitHub ruleset. It matches the live configuration on
+ * `main` in every parameter but one: the compiler hard-codes `strict` and refuses to make it
+ * declarable, while this repository deliberately runs with `strict` off. That contradiction
+ * cannot be removed from this side, so it is measured instead of described — the failure mode
+ * being an export somebody imports, silently re-enabling a setting a ruling turned off.
+ */
+const ruleset = JSON.parse(read(".portulan/compile/github-ruleset.json"));
+const ruleOf = (type: string) =>
+  ruleset.rules.find((r: { type: string }) => r.type === type)?.parameters ?? {};
+
+describe("the exported ruleset and the floor it came from", () => {
+  it("protects exactly the branch the policy names", () => {
+    expect(ruleset.conditions.ref_name.include).toEqual([`refs/heads/${policy.floor!.branch}`]);
+  });
+
+  it("carries the declared checks, pins and all, in order", () => {
+    expect(ruleOf("required_status_checks").required_status_checks).toEqual(policy.floor!.checks);
+  });
+
+  it("carries the declared review count and conversation resolution", () => {
+    expect(ruleOf("pull_request").required_approving_review_count).toBe(policy.floor!.reviews);
+    expect(ruleOf("pull_request").required_review_thread_resolution).toBe(
+      policy.floor!.resolve_conversations,
+    );
+  });
+
+  it("exports `strict` on, which the live floor deliberately has off", () => {
+    expect(ruleOf("required_status_checks").strict_required_status_checks_policy).toBe(true);
+    expect(policy.floor).not.toHaveProperty("strict");
+  });
+
+  it("warns, in the map, that the export must not be imported as-is", () => {
+    expect(map).toContain("must not be imported as-is");
+    expect(map).toContain("strict_required_status_checks_policy");
+  });
+});


### PR DESCRIPTION
The workspace was already GREEN and already curated. What it lacked was the half a machine reads: the tier table argued the policy, and nothing could compile it.

## What this adds

`.portulan/gates.json` — 16 rules and a floor, gate-policy spec 2.2, derived from the existing tier table rather than invented. `portulan compile` now **exits 0**, emitting six `ask` permissions, two hooks, and an importable GitHub ruleset. `doctor` stays GREEN; agent legibility 2 of 5 → 3 of 5.

Two rows in Auto are new words for an old rule rather than a widening: `edit-on-a-working-branch` and `commit-to-a-working-branch` were implied by *push a working branch* and never written down. `gates.json` has to state a tier or have none, and an unstated Auto reads identically to an oversight.

## Two findings from measuring the live floor

The floor was written from the live settings rather than from memory, and the gate map's account of it was accurate in every particular.

**The generated ruleset matches live on every parameter but one.**

| | live on `main` | generated export |
|---|---|---|
| `strict_required_status_checks_policy` | `false` | `true` |

The compiler hard-codes `true` and deliberately refuses to make it declarable. This repository runs `strict` **off** because it forced a rebase whenever `main` moved, and every rebase costs a review round. **So the export must not be imported as-is** — doing so would silently reinstate the cost `branch-freshness` was built to remove. The divergence is pinned by a test rather than by a paragraph.

**`copilot-reviewed` is the only required check with no app pin.** `verify`, `branch-freshness` and `analyze` each carry `app_id 15368`; `copilot-reviewed` carries `null`. A context with no pin is satisfiable by *any* app reporting that name, so the check built to stop a stale verdict is the least constrained of the four. Recorded, not changed — pinning it is a branch-protection change, which is Gated.

## The duplication is now an assertion

The Workspace Definition requires prose↔policy membership to hold both ways. That was a promise; `tests/portulan/gate-policy.test.ts` makes it a check that runs in CI. It was verified by mutation in both directions — a dropped citation and a phantom one each turn it red — because a check that has never failed has not been shown to work.

## What is deliberately not committed

`.claude/settings.json`. Its hook command is an absolute path into the maintainer's plugin cache *including the plugin version*, because the runner does not live under this project. On any other machine that path does not resolve, and **a missing hook fails open** — it would look like enforcement and be nothing. It is git-ignored and regenerated with `portulan compile`.

The open decision, left to the maintainer: `npm i -D @sleepy_panda_srl/portulan` would make the hook path project-relative, and the artifact portable, committable and drift-checkable in CI — at the cost of a dev dependency on a published package.

## Verification

- `npm run build && npm run test:coverage && npm audit --audit-level=high` → **exit 0**
- **491 tests across 26 files** (477 + 14 new), 100% statements/branches/functions/lines on `src/`, 0 vulnerabilities
- `portulan compile` → exit 0 · `compile --check` → exit 0 · `doctor` → GREEN, 8 claims checked
- The macOS-only AppleScript suite was run and genuinely executed (30 tests through `osascript`), not skipped

No consumer-facing behaviour changed, and `chore` bumps no version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)