### PR TITLE
docs(changelog): record 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.3] - 2026-08-26
 
 ### Fixed
 
@@ -50,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `copilot-pull-request-reviewer[bot]` returns **201 Created and adds nobody**, because Copilot is a
   Bot and that endpoint takes Users and Teams. #44 observed the same behaviour and read it as the
   API not working; the narrower cause is what made the fix possible.
-
 
 ## [1.3.2] - 2026-08-20
 


### PR DESCRIPTION
Prerequisite for releasing **1.3.3**. This must land *before* the release runs.

## Why this is not optional

The release workflow **never commits to `main`** — that is the whole reason the tag is the source of
truth and `package.json` stays at `0.0.0-development`. So the changelog entry for a version can only
be written *before* its tag exists, and the window closes permanently once it does.

1.3.1 shipped with no entry and had to be backfilled from its own commits. Releasing 1.3.3 with its
entry still sitting under `## [Unreleased]` would repeat that exactly.

## What changed

`## [Unreleased]` → `## [1.3.3] - 2026-08-26`. **Contents are unchanged** — both sections were
written as the two changes landed, so nothing here is composed after the fact:

- `### Fixed` — the `escapeForJson` work from [#48](https://github.com/marius-cetanas/macos-mail-mcp/pull/48) (closes [#42](https://github.com/marius-cetanas/macos-mail-mcp/issues/42))
- `### Internal` — the `copilot-reviewed` work from [#49](https://github.com/marius-cetanas/macos-mail-mcp/pull/49) (closes [#44](https://github.com/marius-cetanas/macos-mail-mcp/issues/44))

Also collapses a double blank line left behind when I resolved those two branches' competing
`[Unreleased]` sections.

## Why 1.3.3

`scripts/next-version.mjs` derives it, and the release will compute the same thing independently:

```
$ node scripts/next-version.mjs --current 1.3.2 --since v1.3.2
{ "version": "1.3.3", "bump": "patch", "releasable": true, "since": "v1.3.2", "considered": 5 }
```

A patch, from the `perf:` and `fix:` commits. Nothing since v1.3.2 is a `feat` or a breaking change.

Note the two are independent artifacts: this file is maintained by hand, while the **GitHub release
notes** are generated from the commit range by `scripts/release-notes.mjs`.

## Verify

`npm run build && npm run test:coverage && npm audit --audit-level=high` — green: **576 tests across
28 files**, 100% statements/branches/functions/lines on `src/`, 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)