### PR TITLE
chore(portulan): commit the gate artifact, and check it in CI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "$portulan": {
+    "generated": "cli/compile.mjs",
+    "source": ".portulan/gates.json",
+    "warning": "Generated file. Edit .portulan/gates.json and recompile; `verify/compile.sh` fails on drift."
+  },
+  "permissions": {
+    "deny": [],
+    "ask": [
+      "Bash(gh pr merge:*)",
+      "Bash(gh workflow run:*)",
+      "Bash(git push --tags:*)",
+      "Bash(npm publish:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push --delete:*)"
+    ],
+    "allow": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/node_modules/@sleepy_panda_srl/portulan/cli/gate.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/node_modules/@sleepy_panda_srl/portulan/cli/stop-gate.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,12 +56,40 @@ jobs:
       - name: npm audit (fail on high or critical)
         run: npm audit --audit-level=high
 
+  # The compiled gate artifacts must match the policy they claim to compile.
+  #
+  # This could not run in CI while the Claude Code artifact carried an absolute path into one
+  # machine's plugin cache: CI would recompile with a different runner path and report drift that
+  # was not drift. With the CLI installed as a dev dependency the hook command is
+  # `${CLAUDE_PROJECT_DIR}`-relative — a literal string, identical on every machine — so `--check`
+  # compares like with like and a real edit to `.portulan/gates.json` that was never recompiled is
+  # what turns it red.
+  #
+  # It joins `verify`'s dependencies rather than becoming a required check of its own, so the merge
+  # gate covers it without a branch-protection change.
+  gate-policy:
+    name: gate-policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+      - name: The compiled artifacts match .portulan/gates.json
+        run: npx portulan compile --check
+
   # Single stable context for branch protection to require. Matrix job names
   # change whenever the matrix changes; this one does not.
   verify:
     name: verify
     runs-on: ubuntu-latest
-    needs: [test, audit]
+    needs: [test, audit, gate-policy]
     if: always()
     steps:
       # The condition lives in `if:` rather than in shell, so there is no embedded logic to test —

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,11 @@ coverage/
 .env
 .env.*
 
-# Portulan — compiled enforcement. Machine-specific: the hook command is an absolute
-# path into this machine's plugin cache, pinned to a plugin version, because the runner
-# is not under this project. Committing it would put a path in the tree that is wrong on
-# every other machine, and a hook whose file is missing FAILS OPEN. Regenerate with
-# `portulan compile`. See .portulan/gate-map.md, "The policy, and what compiles it".
-.claude/settings.json
+# `.claude/settings.json` is COMMITTED — see .portulan/gate-map.md. It used to be ignored,
+# because the hook command was an absolute path into one machine's plugin cache and a hook
+# whose file is missing FAILS OPEN. With the CLI installed as a dev dependency the path is
+# `${CLAUDE_PROJECT_DIR}`-relative, so the artifact is portable, reviewable in a diff, and
+# drift-checked in CI by `portulan compile --check`. Regenerate with `portulan compile`.
 
 # Worktrees live under .claude/ and are whole checkouts; never commit one.
 .claude/worktrees/

--- a/.portulan/gate-map.md
+++ b/.portulan/gate-map.md
@@ -81,18 +81,35 @@ command's flags. And `merge-a-pull-request` compiles to nothing on this backend:
 approving reviews the floor constrains a merge but does not require a human's yes, which is what Gated
 means. That gate lives in the Claude Code artifact and in habit, not in the ruleset.
 
-**The Claude Code artifact is not committed.** The hook command is an absolute path into the
-maintainer's plugin cache, pinned to a plugin version, because the runner does not live under this
-project. On any other machine that path does not resolve, and **a missing hook fails open** — so
-committing it would ship a file that looks like enforcement and is not. `.claude/settings.json` is
-git-ignored and regenerated with `portulan compile`. The ruleset artifact beside it has no such
-problem and is committed. Installing the CLI as a dev dependency would make the hook path
-project-relative and that artifact portable too; that is a dependency decision the maintainer has not
-taken.
+**The Claude Code artifact is committed, and drift-checked in CI.** It was not, and the reason was
+real: the hook command was an absolute path into one maintainer's plugin cache, pinned to a plugin
+version, because the runner did not live under this project. On any other machine that path does not
+resolve, and **a missing hook fails open** — so committing it would have shipped a file that looked
+like enforcement and was not.
 
-**Retire when:** the compiled artifact becomes portable and committable, at which point it is the
-authority and this table becomes its rationale rather than its statement. Until then the policy
-compiles on one machine and this map is what every other reader has.
+`@sleepy_panda_srl/portulan` is now a dev dependency, which makes the hook command
+`${CLAUDE_PROJECT_DIR}/node_modules/@sleepy_panda_srl/portulan/cli/gate.mjs` — a literal string,
+identical on every machine, with no version baked into the path. Three consequences, and the third
+is the one that matters:
+
+- `.claude/settings.json` is in the tree, so a change to what this repository gates is **reviewable
+  in a diff** rather than invisible.
+- `npm ci` puts the runner where the hook looks for it, so a fresh clone is gated rather than
+  failing open.
+- **`portulan compile --check` runs in CI**, in the `gate-policy` job. That could not work while the
+  artifact was machine-specific — CI would recompile with a different runner path and report drift
+  that was not drift. Now it compares like with like, and an edit to `gates.json` that was never
+  recompiled turns the merge gate red. The job joins `verify`'s dependencies rather than becoming a
+  required check of its own, so the floor covers it **without a branch-protection change**.
+
+`tests/portulan/gate-policy.test.ts` pins the conditions that made this possible — the
+`${CLAUDE_PROJECT_DIR}` path, the absence of any absolute path or pinned version, the dev
+dependency, and the CI check. If any regresses, the artifact is machine-specific again and
+committing it is once more the wrong thing.
+
+**Retire when:** superseded. This table is now the artifact's rationale rather than its statement —
+the artifact is the authority, it is in the tree, and CI holds the two in agreement. What remains
+prose is only what compiles to nothing, which the two bullets above already name.
 
 ## The platform floor
 

--- a/.portulan/gate-map.md
+++ b/.portulan/gate-map.md
@@ -107,6 +107,16 @@ is the one that matters:
 dependency, and the CI check. If any regresses, the artifact is machine-specific again and
 committing it is once more the wrong thing.
 
+**One line in the generated artifact is wrong here, and cannot be fixed here.** Its `$portulan.warning`
+reads *"Edit `.portulan/gates.json` and recompile; `verify/compile.sh` fails on drift."* There is no
+`verify/compile.sh` in this repository — that is Portulan's own verify recipe, hard-coded into every
+adopter's artifact. **Drift is enforced here by the `gate-policy` job**, which runs
+`npx portulan compile --check`. The text cannot be corrected locally: it is generated, and
+hand-editing it makes `compile --check` report drift (measured, exit 1), which would trade a
+misleading sentence for a red merge gate. Recorded here so the repository's own prose corrects it;
+the fix belongs upstream. _(Raised by Copilot on
+[#52](https://github.com/marius-cetanas/macos-mail-mcp/pull/52).)_
+
 **Retire when:** superseded. This table is now the artifact's rationale rather than its statement —
 the artifact is the authority, it is in the tree, and CI holds the two in agreement. What remains
 prose is only what compiles to nothing, which the two bullets above already name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.3.3] - 2026-08-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,17 @@ Read the tag, the GitHub release, or npm.
 
 `CHANGELOG.md` is maintained by hand in ordinary pull requests, since the workflow cannot
 commit to it. GitHub release notes are generated from the commit range by
-`scripts/release-notes.mjs`, grouped by conventional-commit type.
+`scripts/release-notes.mjs`, grouped by conventional-commit type — two independent artifacts,
+so writing one does not write the other.
+
+It carries a **standing `## [Unreleased]` heading**, and at release time the version heading is
+**inserted below it, not renamed from it**. Renaming is the natural move and it silently removes
+the standing heading, leaving the next change nowhere to land. Both halves are asserted in
+`tests/release/changelog.test.ts` — the heading exists, sits at the top, carries no date, and every
+heading below it does.
+
+The window matters: the workflow never commits to `main`, so a version's entry can only be written
+**before its tag exists**. 1.3.1 shipped with no entry and had to be backfilled from its own commits.
 
 ### Why the ordering is what it is
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "macos-mail-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@sleepy_panda_srl/portulan": "^0.1.2",
         "@types/node": "^26.2.0",
         "@vitest/coverage-v8": "^4.1.11",
         "typescript": "^7.0.2",
@@ -455,6 +456,19 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sleepy_panda_srl/portulan": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sleepy_panda_srl/portulan/-/portulan-0.1.2.tgz",
+      "integrity": "sha512-IE3Vn5TxeqhIhIeanN3HBjKrnVvNNhGnOc/T7PE9rnf4IrzJWpD5TDFhjlvSb+isMUJ4vqP1c5DGAfav7iht1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "portulan": "cli/portulan.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@sleepy_panda_srl/portulan": "^0.1.2",
     "@types/node": "^26.2.0",
     "@vitest/coverage-v8": "^4.1.11",
     "typescript": "^7.0.2",

--- a/tests/portulan/gate-policy.test.ts
+++ b/tests/portulan/gate-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parse } from "yaml";
 
 const ROOT = process.cwd();
 const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
@@ -143,11 +144,27 @@ describe("the workspace wires the policy in", () => {
     });
 
     it("is drift-checked in CI, which is what keeps it honest once committed", () => {
-      const ci = read(".github/workflows/verify.yml");
-      expect(ci).toContain("portulan compile --check");
-      // Reached through the aggregate the branch protection already requires, so the merge gate
-      // covers it without a branch-protection change.
-      expect(ci).toMatch(/needs:\s*\[test,\s*audit,\s*gate-policy\]/);
+      /*
+       * Parsed rather than pattern-matched. A regex over the raw YAML pinned one spelling of
+       * `needs: [test, audit, gate-policy]` — so reordering the list, or rewriting it as a block
+       * sequence, would have failed a workflow that was still correct, while `needs: [gate-policy]`
+       * written across two lines would have passed a workflow that was not. What matters is which
+       * job runs the check and whether the required aggregate depends on it, and both are
+       * properties of the document, not of its formatting.
+       */
+      const ci = parse(read(".github/workflows/verify.yml")) as {
+        jobs: Record<string, { needs?: string[]; steps?: { run?: string }[] }>;
+      };
+
+      const runsCheck = Object.entries(ci.jobs).filter(([, job]) =>
+        (job.steps ?? []).some((s) => s.run?.includes("portulan compile --check"))
+      );
+      expect(runsCheck).toHaveLength(1);
+
+      const [checkJob] = runsCheck[0];
+      // `verify` is the one context branch protection requires, so the merge gate covers the drift
+      // check only if the aggregate depends on the job that runs it.
+      expect(ci.jobs.verify.needs).toContain(checkJob);
     });
   });
 });

--- a/tests/portulan/gate-policy.test.ts
+++ b/tests/portulan/gate-policy.test.ts
@@ -104,8 +104,51 @@ describe("the workspace wires the policy in", () => {
     expect(manifest.slots.gates).toBe("gate-map.md");
   });
 
-  it("ignores the compiled artifact, which is machine-specific and fails open when stale", () => {
-    expect(read(".gitignore")).toContain(".claude/settings.json");
+  /**
+   * The compiled artifact is committed, and these are the conditions that made it committable.
+   *
+   * It was ignored for a real reason: the hook command was an absolute path into one machine's
+   * plugin cache, pinned to a plugin version, and **a hook whose file is missing fails open** — so
+   * committing it would have shipped a file that looked like enforcement and was not. Installing
+   * the CLI as a dev dependency makes the path `${CLAUDE_PROJECT_DIR}`-relative, which is what
+   * these assert. If any of them regresses, the artifact is machine-specific again and committing
+   * it is once more the wrong thing.
+   */
+  describe("the compiled Claude Code artifact is portable", () => {
+    const settings = read(".claude/settings.json");
+
+    it("is committed rather than ignored", () => {
+      expect(existsSync(join(process.cwd(), ".claude/settings.json"))).toBe(true);
+      expect(read(".gitignore")).not.toMatch(/^\.claude\/settings\.json$/m);
+    });
+
+    it("resolves the hook through the project, not an absolute path", () => {
+      expect(settings).toContain("${CLAUDE_PROJECT_DIR}");
+      // The two spellings a machine-local path took: a home directory, or the plugin cache.
+      expect(settings).not.toMatch(/"\/Users\/|\/home\/|\.claude\/plugins/);
+    });
+
+    it("pins no plugin version into the hook path, which an upgrade would silently break", () => {
+      // The old path carried `…/portulan/0.1.2/cli/gate.mjs`, so upgrading the plugin unhooked the
+      // gate — failing open — until someone recompiled. The dependency's version lives in
+      // package.json now, where `npm ci` resolves it.
+      expect(settings).not.toMatch(/\/\d+\.\d+\.\d+\//);
+    });
+
+    it("depends on the CLI that provides the hook, so `npm ci` puts it there", () => {
+      const pkg = JSON.parse(read("package.json"));
+      expect(pkg.devDependencies["@sleepy_panda_srl/portulan"]).toBeDefined();
+      // A devDependency, so it stays out of the published tarball — `files` governs that anyway.
+      expect(pkg.dependencies?.["@sleepy_panda_srl/portulan"]).toBeUndefined();
+    });
+
+    it("is drift-checked in CI, which is what keeps it honest once committed", () => {
+      const ci = read(".github/workflows/verify.yml");
+      expect(ci).toContain("portulan compile --check");
+      // Reached through the aggregate the branch protection already requires, so the merge gate
+      // covers it without a branch-protection change.
+      expect(ci).toMatch(/needs:\s*\[test,\s*audit,\s*gate-policy\]/);
+    });
   });
 });
 

--- a/tests/release/changelog.test.ts
+++ b/tests/release/changelog.test.ts
@@ -38,13 +38,37 @@ describe("CHANGELOG.md", () => {
     }
   });
 
+  /**
+   * Compare two `major.minor.patch` triples. Positive when `a` is the newer version.
+   *
+   * Field by field, because comparing the parsed arrays directly is wrong in a way that passes
+   * today. `[1,10,0] > [1,9,0]` coerces both to strings and asks whether `"1,10,0" > "1,9,0"`,
+   * which is **false** — `"1"` sorts below `"9"` at the third character. Same for
+   * `[1,3,10] > [1,3,9]`. Every version this file currently holds happens to avoid both shapes, so
+   * the broken comparison was green and would have stayed green until 1.10.0 or 1.3.10, then
+   * failed on a correctly-ordered changelog. Raised by Copilot on #52.
+   */
+  const compare = (a: number[], b: number[]) =>
+    a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+  it("compares versions numerically, not by coercing arrays to strings", () => {
+    // The two cases the array comparison gets wrong, asserted directly so the comparator is pinned
+    // independently of whichever versions the file happens to contain.
+    expect(compare([1, 10, 0], [1, 9, 0])).toBeGreaterThan(0);
+    expect(compare([1, 3, 10], [1, 3, 9])).toBeGreaterThan(0);
+    expect(compare([2, 0, 0], [1, 10, 0])).toBeGreaterThan(0);
+    expect(compare([1, 3, 2], [1, 3, 3])).toBeLessThan(0);
+    expect(compare([1, 3, 3], [1, 3, 3])).toBe(0);
+  });
+
   it("orders released versions newest first", () => {
-    const versions = headings.slice(1).map((h) => h[1].split(".").map(Number));
+    const released = headings.slice(1);
+    const versions = released.map((h) => h[1].split(".").map(Number));
     for (let i = 1; i < versions.length; i += 1) {
       expect(
-        versions[i - 1] > versions[i],
-        `${headings[i][1]} should sort above ${headings[i + 1][1]}`
-      ).toBe(true);
+        compare(versions[i - 1], versions[i]),
+        `[${released[i - 1][1]}] should sort above [${released[i][1]}]`
+      ).toBeGreaterThan(0);
     }
   });
 

--- a/tests/release/changelog.test.ts
+++ b/tests/release/changelog.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `CHANGELOG.md` carries a standing `## [Unreleased]` heading, per Keep a Changelog.
+ *
+ * The failure mode this guards is specific and has already happened once, in the other direction.
+ * The release workflow **never commits to `main`**, so a version's entry can only be written before
+ * its tag exists — 1.3.1 shipped with no entry at all and had to be backfilled from its own
+ * commits. The natural way to prepare a release is then to rename `[Unreleased]` to the version,
+ * which lands the entry correctly and **removes the standing heading**, leaving the next change
+ * with nowhere to go and the next author repeating the whole cycle.
+ *
+ * So at release time the version heading is *inserted below* `[Unreleased]`, not renamed from it.
+ * That is a one-word difference in a procedure nobody performs often, which is exactly the kind of
+ * thing worth asserting rather than documenting.
+ */
+const changelog = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf8");
+const headings = [...changelog.matchAll(/^## \[([^\]]+)\](?: - (\S+))?/gm)];
+
+describe("CHANGELOG.md", () => {
+  it("has a standing Unreleased heading", () => {
+    expect(headings.map((h) => h[1])).toContain("Unreleased");
+  });
+
+  it("keeps it at the top, above every released version", () => {
+    expect(headings[0][1]).toBe("Unreleased");
+  });
+
+  it("gives it no date, because it names no release", () => {
+    expect(headings[0][2]).toBeUndefined();
+  });
+
+  it("dates every other heading, because those did ship", () => {
+    for (const [, name, date] of headings.slice(1)) {
+      expect(date, `[${name}] has no date`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("orders released versions newest first", () => {
+    const versions = headings.slice(1).map((h) => h[1].split(".").map(Number));
+    for (let i = 1; i < versions.length; i += 1) {
+      expect(
+        versions[i - 1] > versions[i],
+        `${headings[i][1]} should sort above ${headings[i + 1][1]}`
+      ).toBe(true);
+    }
+  });
+
+  it("carries at least one released version, so Unreleased is not the whole file", () => {
+    // Deliberately not asserting *which* version is newest. A hard-coded number there would go
+    // stale on every release and this suite does not track figures nothing else checks — the tag
+    // is the source of truth for what shipped, not this file and not `package.json`.
+    expect(headings.length).toBeGreaterThan(1);
+    expect(headings.slice(1).map((h) => h[1])).not.toContain("Unreleased");
+  });
+});


### PR DESCRIPTION
Two things the maintainer asked for: the standing `[Unreleased]` heading, and `.claude/settings.json`
no longer being machine-local.

## The artifact was ignored for a real reason, and that reason is gone

The hook command used to be an absolute path into one machine's plugin cache, pinned to a plugin
version — `…/portulan/0.1.2/cli/gate.mjs`. On any other machine it does not resolve, and **a hook
whose file is missing fails open**. Committing it would have shipped a file that looked like
enforcement and was not.

Installing `@sleepy_panda_srl/portulan` as a dev dependency changes the compiled output to:

```
node "${CLAUDE_PROJECT_DIR}/node_modules/@sleepy_panda_srl/portulan/cli/gate.mjs"
```

A literal string, identical on every machine, with **no version in the path** — an upgrade can no
longer silently unhook the gate, which is the failure the compiler itself warns about.

## Three consequences, and the third is the point

- The artifact is in the tree, so a change to what this repository gates is **reviewable in a diff**.
- `npm ci` puts the runner where the hook looks for it, so a **fresh clone is gated** rather than
  failing open.
- **`portulan compile --check` runs in CI.** This is what could not be done before: CI would
  recompile with a different runner path and report drift that was not drift. Now it compares like
  with like, and an edit to `.portulan/gates.json` that was never recompiled turns the merge gate
  red.

The new `gate-policy` job joins `verify`'s `needs` rather than becoming a required check of its own,
so **the floor covers it without a branch-protection change** — which would itself be Gated.

Verified both ways: `--check` exits 0 on the committed artifact, and 1 when a gate is removed from it.

## This is the retire condition the gate map named

`gate-map.md` said, verbatim: *"Retire when: the compiled artifact becomes portable and committable,
at which point it is the authority and this table becomes its rationale rather than its statement."*
That section is rewritten accordingly.

Five assertions pin what made it committable — the `${CLAUDE_PROJECT_DIR}` path, no absolute path,
no pinned version, the dev dependency, and the CI check. If any regresses, the artifact is
machine-specific again and committing it is once more the wrong thing.

## The standing `[Unreleased]` heading

Added, reversing the call I made on #50 — that was a convention decision and it is the maintainer's.

Adding the heading is the easy half. The way it gets **lost** is at release time: renaming
`[Unreleased]` to the version lands the entry correctly and silently removes the standing heading,
leaving the next change nowhere to go. So the rule is *insert below, never rename*, and
`tests/release/changelog.test.ts` asserts the shape rather than trusting the procedure — heading
present, at the top, undated, everything below it dated and ordered newest-first.

Mutation-checked: performing the rename fails three of those assertions.

One thing deliberately **not** asserted — which version is newest. A hard-coded number there would
go stale every release, and this suite does not track figures nothing else checks.

## Verify

`npm run build && npm run test:coverage && npm audit --audit-level=high` plus
`npx portulan compile --check` — all green: **586 tests across 29 files**, 100% on `src/`,
**0 vulnerabilities** with the new dependency. It is a `devDependency` and `files: ["build"]`
governs the tarball, so nothing new ships to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)