### PR TITLE
docs(ci): correct the claim that asking fixes the bot-author hole

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,6 +22,14 @@
 # job now requests the round itself when none is pending — at most once per run, and never when the
 # ruleset already has one in flight.
 #
+# ## Asking does not cover a Dependabot pull request (#58)
+#
+# Measured on #55, #56 and #57: the mutation is accepted, the job logs that it asked, and no
+# `review_requested` event is ever recorded — so all three expired red and no push could have
+# changed that. Not a token problem; this job's own log reports `PullRequests: write`. Requested
+# under a user-scoped token the same three drew a round in five seconds. Until #58 settles the
+# mechanism, a Dependabot pull request needs the round requested by hand and this job re-run.
+#
 # ## `pull_request_review` is deliberately not a trigger
 #
 # It would be the obvious way to turn the check green the moment a review lands, and it does not
@@ -52,6 +60,10 @@ jobs:
     # round in 16 hours against `main` while #43/#45/#46/#48 were each requested one second after
     # opening. Both produced a red required check that no push could turn green. See #44 and
     # `scripts/copilot-round.mjs`.
+    #
+    # The write scope is what the ask needs, and it is not what the ask lacks on a Dependabot pull
+    # request: the token carries it there and the request still records nothing (#58). Widening
+    # this further would not help — the scope is already granted.
     #
     # Job-level rather than workflow-level, because job-level REPLACES the workflow block rather
     # than merging with it: declared in both places, whichever sits here is what the token gets,

--- a/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
+++ b/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
@@ -7,9 +7,11 @@ v4.37.9, both `init` and `analyze`, SHA-pinned), **#55** (`@types/node` 26.2.0 �
 `4997f61`, three commits past `0bfa963`, and green: **536 passed / 51 skipped across 29 files**, 100%
 statements/branches/functions/lines on `src/`, 0 vulnerabilities, `portulan compile --check` GREEN.
 The 51 skips are the macOS-only AppleScript tests, as always off a Mac. Verified locally per branch
-**and** on the three-way merge result before any of them landed. **No open pull requests.** One open
-issue: **#58**. Nothing consumer-facing shipped, so no release is owed — all three are `chore`, which
-the resolver types as no bump.
+**and** on the three-way merge result before any of them landed. **The Dependabot queue is empty.**
+Open at the time of writing: issue **#58**, and **#59** — the pull request carrying this file and the
+comment corrections it describes, green and unmerged. If you are reading this on `main`, #59 landed;
+if the corrections below are not in the tree you are looking at, it did not. Nothing consumer-facing
+shipped, so no release is owed — all three are `chore`, which the resolver types as no bump.
 
 **All three were blocked by the same thing, and it was not the change.** Every check green except
 `copilot-reviewed`, which is required, on all three, each burning the full 600s budget. That is the

--- a/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
+++ b/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
@@ -71,7 +71,8 @@ which side GitHub keys on is *not established*. Recorded as unknown rather than 
   permissions rationale now also says the write scope is granted and insufficient, so nobody widens
   a scope that is already wide. The test file's `describe` comment now says what those assertions
   cover and what they cannot: injected I/O cannot observe a mutation that lies, which is why the
-  suite was green for a week while the thing it describes did not work.
+  suite was green for the six days between #49 merging and today while the thing it describes did
+  not work.
 
 **Open questions.** *(human-owned)*
 - Does GitHub key the refusal on the pull request's author or on the requesting actor? Settling it

--- a/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
+++ b/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
@@ -1,0 +1,93 @@
+# Handoff — a fix that never worked where it was aimed
+
+**State.** Three Dependabot pull requests opened and merged today: **#57** (`codeql-action` v4.37.8 →
+v4.37.9, both `init` and `analyze`, SHA-pinned), **#55** (`@types/node` 26.2.0 → 26.4.0, dev) and
+**#56** (`zod` 4.4.3 → 4.5.2, runtime). All three were lockfile- or workflow-only — neither
+`package.json` range changed, since both caret ranges already admitted the new version. `main` is at
+`4997f61`, three commits past `0bfa963`, and green: **536 passed / 51 skipped across 29 files**, 100%
+statements/branches/functions/lines on `src/`, 0 vulnerabilities, `portulan compile --check` GREEN.
+The 51 skips are the macOS-only AppleScript tests, as always off a Mac. Verified locally per branch
+**and** on the three-way merge result before any of them landed. **No open pull requests.** One open
+issue: **#58**. Nothing consumer-facing shipped, so no release is owed — all three are `chore`, which
+the resolver types as no bump.
+
+**All three were blocked by the same thing, and it was not the change.** Every check green except
+`copilot-reviewed`, which is required, on all three, each burning the full 600s budget. That is the
+**bot author** hole #44 named and #49 was written to close. It is not closed.
+
+## The measurement, and the hypothesis it killed
+
+`scripts/copilot-round.mjs` asks for the round when none is pending, and the job log says the ask
+succeeded — that line is only reachable when `requestReviews` resolves without throwing. But the
+timelines of #55, #56 and #57 carry **no `review_requested` event at all**, from any actor.
+
+**My first explanation was wrong, and the log said so.** GitHub documents a read-only `GITHUB_TOKEN`
+for Dependabot-triggered runs, which fit perfectly and would have been a satisfying answer. The head
+of the same job log:
+
+```
+GITHUB_TOKEN Permissions
+  Contents: read
+  Metadata: read
+  PullRequests: write
+Secret source: Dependabot
+```
+
+The scope was granted. The mutation was accepted with everything it needed and recorded nothing —
+a success code for an action that did not happen, which is the exact shape `COPILOT_REVIEWER`'s own
+comment already documents for the REST endpoint it replaced. The lesson is not new here, it is just
+newly mine: **a mechanism that explains the symptom is not thereby the mechanism.** Reading the top
+of a log I had already read the bottom of cost thirty seconds and saved a wrong fix.
+
+The controls, all measured today or read off timelines:
+
+| PR author | Requester | `review_requested`? | Round? |
+|---|---|---|---|
+| Dependabot (#55/#56/#57) | `github-actions[bot]` | **no** | **no**, 600s |
+| human (#49) | `github-actions[bot]` | yes | yes |
+| Dependabot (#47) | `marius-cetanas` | yes | yes, 63s |
+| Dependabot (#55/#56/#57) | `marius-cetanas` | yes | yes, **≤5s** |
+
+So Copilot is not declining Dependabot — it reviewed all three within five seconds of a user-token
+request. The failing combination is **bot-authored pull request asked by the Actions token**, and
+which side GitHub keys on is *not established*. Recorded as unknown rather than guessed at.
+
+**Decisions + why.**
+- **Unblocked by requesting the round under a user token, then re-running the failed job** — because
+  it is the only lever that works today, and it satisfies the gate honestly rather than around it:
+  the round lands on the current head, which is the whole point of the check. Alternatives: widening
+  the check to exempt bot authors (guts the guarantee), admin-merging past a red required check
+  (routes around the floor, and `enforce_admins` is on for a reason).
+- **Merged all three, squashed, after explicit approval** — merge is Gated; approval was asked for
+  and given per the gate map, not assumed from "address the open PRs".
+- **Did not build a mechanism fix** — I cannot distinguish author-keyed from requester-keyed from
+  outside, and a speculative `pull_request_target` request workflow would be a change to a required
+  check justified by a guess. It also may not help: a `pull_request_target` run's actor is still
+  `github-actions[bot]`, the very side that fails.
+- **Corrected the tree instead of only the record.** `copilot-round.mjs` said *"Asking here fixes
+  both"*. It does not, and it has been false since #49 merged — DoD condition 4. The workflow's
+  permissions rationale now also says the write scope is granted and insufficient, so nobody widens
+  a scope that is already wide. The test file's `describe` comment now says what those assertions
+  cover and what they cannot: injected I/O cannot observe a mutation that lies, which is why the
+  suite was green for a week while the thing it describes did not work.
+
+**Open questions.** *(human-owned)*
+- Does GitHub key the refusal on the pull request's author or on the requesting actor? Settling it
+  needs an experiment on the live repository — e.g. a non-Dependabot bot-authored pull request, or
+  the same ask from a PAT-backed step. Everything downstream waits on this.
+- Should the check re-verify `isRoundPending()` after the mutation returns, so a request that did
+  not take says so? It turns today's silent no-op loud — the first principle here — but it is a
+  behaviour change to a required check, so it is proposed in #58 and not taken.
+- **A lockfile-only pull request satisfies this gate with a round that reviewed nothing.** Copilot
+  answered #55 and #56 with *"Copilot wasn't able to review any files in this pull request."* That
+  is a landed round on the head and the check counts it, correctly by its own definition. Whether
+  the definition is the wanted one is a question for whoever next touches the gate.
+
+**Next action.** #58 is the thread. Nothing is blocked on it — Dependabot pull requests merge today
+via request-by-hand then re-run, which is written into the workflow header so the next person meets
+it before the red check rather than after.
+
+**Recoverability.** Nothing partial. The three branches were deleted by the squash-merges; `main` is
+green on `4997f61`; no tag was pushed and no release was run, so the published version is unchanged
+at 1.3.3. The only edits outside `main` are the comment corrections on this branch, which are
+documentation and carry no behaviour.

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -187,8 +187,13 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  * said "ten", which reproduces from no query at all.
  *
  * Both present identically: a red required check with no explanation, which reads as though the
- * change were at fault. Widening the ruleset's `ref_name` would fix only the first. Asking here
- * fixes both, because it stops depending on which pull requests the ruleset chooses to notice.
+ * change were at fault. Widening the ruleset's `ref_name` would fix only the first, so this asks
+ * instead, on the reasoning that asking stops depending on which pull requests the ruleset chooses
+ * to notice.
+ *
+ * **Measured on 2026-09-01, that reasoning holds for the first hole and not the second.** The ask
+ * is a silent no-op on a Dependabot pull request — see the section below. The claim that it "fixes
+ * both" stood here for a week and was false the whole time; #58 carries the measurement.
  *
  * Asked at most once per run, and only when nothing is pending — the ordinary case already has a
  * request in flight a second after opening, and a duplicate would be noise.
@@ -199,6 +204,24 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  * every poll sees the request still on order, nothing re-asks, and the check expires red. That is
  * exactly the pre-#44 behaviour rather than a regression, but the log will say "requested already"
  * throughout, which is the opposite of a clue.
+ *
+ * **Worse, the ask itself can be accepted and do nothing, and the log then reads as a success.**
+ * On #55, #56 and #57 — Dependabot pull requests, 2026-09-01 — `requestReviews` resolved without
+ * throwing, so this logged `requested: no round was on order, asked … for one`, and no
+ * `review_requested` event was ever recorded on any of the three. All three expired red.
+ *
+ * It is not the token. That job's log reports `PullRequests: write` under `GITHUB_TOKEN
+ * Permissions`, with `Secret source: Dependabot` — the mutation was accepted with the scope it
+ * needed and recorded nothing. Nor is it Copilot declining Dependabot: requested under a
+ * user-scoped token, the same three pull requests drew a round on the same heads within five
+ * seconds, which is how they were unblocked. The same code path on a human-authored pull request
+ * (#49) does record `review_requested by github-actions[bot]`.
+ *
+ * So the failing combination is a bot-authored pull request asked by the Actions token, and which
+ * side GitHub keys on is not established. Until it is, a Dependabot pull request needs the round
+ * requested by hand and the job re-run. #58 has the controls and the suggested fix — re-checking
+ * `isRoundPending()` after the mutation returns, so a request that did not take says so instead of
+ * reporting success. That is a behaviour change to a required check, so it is not made here.
  *
  * I/O is injected so the loop is testable without a network or a clock.
  *

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -193,7 +193,8 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  *
  * **Measured on 2026-09-01, that reasoning holds for the first hole and not the second.** The ask
  * is a silent no-op on a Dependabot pull request — see the section below. The claim that it "fixes
- * both" stood here for a week and was false the whole time; #58 carries the measurement.
+ * both" stood here from #49 (2026-08-26) to 2026-09-01 and was false throughout; #58 carries the
+ * measurement.
  *
  * Asked at most once per run, and only when nothing is pending — the ordinary case already has a
  * request in flight a second after opening, and a duplicate would be noise.

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -202,7 +202,7 @@ describe("hasPendingRequest", () => {
  * These assertions cover the loop's decision to ask, which is all they ever covered. **They do not
  * establish that asking works**, and on a Dependabot pull request it does not: the mutation is
  * accepted and records nothing (#58). Injected I/O cannot see that, so nothing here fails when it
- * happens — which is why it took three red pull requests to notice.
+ * happens — which is why it took three red pull requests, six days after #49 merged, to notice.
  */
 describe("awaitRound requesting the round (#44)", () => {
   /** Serves the two endpoints the loop reads. Pending state is injected separately, as in the CLI. */

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -198,6 +198,11 @@ describe("hasPendingRequest", () => {
  * non-default base, which the ruleset's `~DEFAULT_BRANCH` condition never matches, and a bot author
  * — #47 drew nothing in 16 hours against `main` while #43/#45/#46/#48 were each requested one
  * second after opening.
+ *
+ * These assertions cover the loop's decision to ask, which is all they ever covered. **They do not
+ * establish that asking works**, and on a Dependabot pull request it does not: the mutation is
+ * accepted and records nothing (#58). Injected I/O cannot see that, so nothing here fails when it
+ * happens — which is why it took three red pull requests to notice.
  */
 describe("awaitRound requesting the round (#44)", () => {
   /** Serves the two endpoints the loop reads. Pending state is injected separately, as in the CLI. */


### PR DESCRIPTION
Documentation only. No behaviour changes, no new checks — this removes a claim the tree contradicts and records what replaced it. Refs #58.

## What was false

`scripts/copilot-round.mjs` has said since #49:

> Widening the ruleset's `ref_name` would fix only the first. Asking here fixes both, because it stops depending on which pull requests the ruleset chooses to notice.

Measured on #55, #56 and #57 today, asking here fixes the non-default-base hole and **not** the bot-author one — the hole #47 exposed and #49 was written for. On a Dependabot pull request the `requestReviews` mutation resolves without throwing, so the job logs `requested: no round was on order, asked … for one`, and no `review_requested` event is ever recorded. All three expired red at 600s. No push could have turned them green.

That is DoD condition 4: the tree stating a fact the tree contradicts.

## It is not the token

That was the obvious explanation — GitHub documents a read-only `GITHUB_TOKEN` for Dependabot runs — and it is wrong. The head of the same job log:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  PullRequests: write
Secret source: Dependabot
```

The scope was granted and the mutation recorded nothing. Nor is Copilot declining Dependabot: requested under a user-scoped token, the same three pull requests drew a round on the same heads within five seconds, which is how they were unblocked and merged.

| PR author | Requester | `review_requested`? | Round? |
|---|---|---|---|
| Dependabot (#55/#56/#57) | `github-actions[bot]` | **no** | **no**, 600s |
| human (#49) | `github-actions[bot]` | yes | yes |
| Dependabot (#47) | `marius-cetanas` | yes | yes, 63s |
| Dependabot (#55/#56/#57) | `marius-cetanas` | yes | yes, **≤5s** |

Which side GitHub keys on — author or requesting actor — is not established, and is left as the open question in #58 rather than guessed at.

## Changes

- **`scripts/copilot-round.mjs`** — the `## Why this asks (#44)` block no longer claims the ask covers both holes; `## What this still does not cover` carries the measurement, the controls, and the fact that the ask itself can be accepted and do nothing while the log reads as success.
- **`.github/workflows/copilot-review.yml`** — records that the write scope is granted and insufficient, so nobody widens a scope that is already wide, and names the workaround in the file header, where a reader meets it before the red check rather than after.
- **`tests/workflows/copilot-round.test.ts`** — the `awaitRound` `describe` comment now says what those assertions cover and what they cannot: injected I/O cannot observe a mutation that lies, which is why the suite stayed green for a week while the thing it describes did not work.
- **`.portulan/handoffs/2026-09-01-…`** — the session record, per the every-session rule.

No assertion ships with this. The claim being removed is not machine-checkable — it is about GitHub's live behaviour — and the change adds no claim needing one. The check that *would* catch this is proposed in #58 (re-verify `isRoundPending()` after the mutation returns) and deliberately not taken here, since it changes a required check's behaviour.

## Verification

`npm run build && npm run test:coverage && npm audit --audit-level=high` on this branch: **536 passed / 51 skipped across 29 files**, 100% statements (263/263), branches (100/100), functions (64/64) and lines (262/262) on `src/`, 0 vulnerabilities. `npx portulan compile --check` GREEN. The 51 skips are the two macOS-only AppleScript files, as always off a Mac.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw)_