### PR TITLE
docs(portulan): the handoff missed #54, which this session then reproduced

### DIFF
--- a/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
+++ b/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
@@ -8,10 +8,10 @@ v4.37.9, both `init` and `analyze`, SHA-pinned), **#55** (`@types/node` 26.2.0 �
 statements/branches/functions/lines on `src/`, 0 vulnerabilities, `portulan compile --check` GREEN.
 The 51 skips are the macOS-only AppleScript tests, as always off a Mac. Verified locally per branch
 **and** on the three-way merge result before any of them landed. **The Dependabot queue is empty.**
-Open at the time of writing: issue **#58**, and **#59** — the pull request carrying this file and the
-comment corrections it describes, green and unmerged. If you are reading this on `main`, #59 landed;
-if the corrections below are not in the tree you are looking at, it did not. Nothing consumer-facing
-shipped, so no release is owed — all three are `chore`, which the resolver types as no bump.
+Open issues: **#54** (already open, and it should have been read before this session touched the
+gate — see below) and **#58**, filed here. #59 carried this file and the comment corrections and has
+since merged. Nothing consumer-facing shipped, so no release is owed — all three are `chore`, which
+the resolver types as no bump.
 
 **All three were blocked by the same thing, and it was not the change.** Every check green except
 `copilot-reviewed`, which is required, on all three, each burning the full 600s budget. That is the
@@ -81,12 +81,25 @@ which side GitHub keys on is *not established*. Recorded as unknown rather than 
 - Should the check re-verify `isRoundPending()` after the mutation returns, so a request that did
   not take says so? It turns today's silent no-op loud — the first principle here — but it is a
   behaviour change to a required check, so it is proposed in #58 and not taken.
-- **A lockfile-only pull request satisfies this gate with a round that reviewed nothing.** Copilot
+- **A lockfile-only pull request satisfies this gate with a round that reviewed nothing** — and
+  this is **#54**, which was open before this session started and which I did not read. Copilot
   answered #55 and #56 with *"Copilot wasn't able to review any files in this pull request."* That
-  is a landed round on the head and the check counts it, correctly by its own definition. Whether
-  the definition is the wanted one is a question for whoever next touches the gate.
+  is a landed round on the head, the check counts it, and I merged both on it. #54 describes the
+  same fail-open with a different body (*"encountered an error and was unable to review"*) and
+  judges it rare, needing Copilot to fail. The lockfile body is not rare: it is deterministic, and
+  Dependabot produces it weekly. Measured today and written up on #54.
+- **The two issues interact, and the order matters.** #58 fails closed and #54 fails open, on the
+  same pull requests. Fixing #58 alone stops Dependabot bumps dying red and starts them sailing
+  through #54's hole instead — so #54's policy question (is a diff Copilot will not read `not-owed`,
+  or grounds for a human's yes?) wants settling first.
 
-**Next action.** #58 is the thread. Nothing is blocked on it — Dependabot pull requests merge today
+**The process note this session earns.** I listed open *pull requests* and reasoned as though that
+were the repository's open work. #54 was sitting in the issue list the whole time, describing the
+exact gate I spent the session inside, and I met its failure mode twice and merged on it. Reading
+the open issues costs one call and would have changed what I looked at. _(The same shape as the
+handoff's own "no open pull requests", written from a listing that was true when it ran.)_
+
+**Next action.** #54 first, then #58 — the sequencing is on both threads. Nothing is blocked on it — Dependabot pull requests merge today
 via request-by-hand then re-run, which is written into the workflow header so the next person meets
 it before the red check rather than after.
 

--- a/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
+++ b/.portulan/handoffs/2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md
@@ -99,11 +99,13 @@ exact gate I spent the session inside, and I met its failure mode twice and merg
 the open issues costs one call and would have changed what I looked at. _(The same shape as the
 handoff's own "no open pull requests", written from a listing that was true when it ran.)_
 
-**Next action.** #54 first, then #58 — the sequencing is on both threads. Nothing is blocked on it — Dependabot pull requests merge today
-via request-by-hand then re-run, which is written into the workflow header so the next person meets
-it before the red check rather than after.
+**Next action.** #54 first, then #58 — the sequencing argument is on both threads. Neither blocks
+work: a Dependabot pull request merges today by requesting the round by hand and re-running the job,
+which is written into the workflow header so the next person meets it before the red check rather
+than after.
 
-**Recoverability.** Nothing partial. The three branches were deleted by the squash-merges; `main` is
-green on `4997f61`; no tag was pushed and no release was run, so the published version is unchanged
-at 1.3.3. The only edits outside `main` are the comment corrections on this branch, which are
-documentation and carry no behaviour.
+**Recoverability.** Nothing partial. The three Dependabot branches were deleted by their
+squash-merges; no tag was pushed and no release was run, so the published version is unchanged at
+1.3.3. `main` was green at `4997f61` when this was written and has since taken #59 (the comment
+corrections and this file) and #60 (the amendment above), both documentation carrying no
+behaviour.


### PR DESCRIPTION
Documentation only — one file, `.portulan/handoffs/2026-09-01-…`. Follows #59, which landed the handoff with a false statement in it.

## What was wrong

The state section said the open issues were **#58**. **#54** was open before the session started, and it describes the exact gate the whole session was spent inside. I listed open *pull requests*, read that as the repository's open work, and never looked at the issues.

That is not a cosmetic miss. #54 says `copilot-reviewed` counts a Copilot round with no review in it as a review — and I met that failure twice and merged on it:

| PR | diff | round on head | check |
|---|---|---|---|
| #55 | `package-lock.json` only | *"Copilot wasn't able to review any files in this pull request."* | success |
| #56 | `package-lock.json` only | same body | success |
| #57 | `.github/workflows/codeql.yml` | `🟢 Approval recommended`, 1/1 files reviewed | success |

#57 is the control — same session, same requester, a diff Copilot reads, a real verdict.

The handoff already recorded this as an open question in its own words, without recognising it was an issue already filed. Naming it as an independent observation, when it was a known defect with a suggested fix sitting in the tracker, is the more misleading half.

## What the measurement adds to #54

#54 judges its failure rare — *"Requires Copilot to error, which has happened once here."* The lockfile body needs nothing to go wrong. It is what Copilot returns for a diff it will not read, it is deterministic, and Dependabot produces it weekly. So the fail-open path is the default outcome for the most common class of pull request here, not a coin flip. Written up on [#54](https://github.com/marius-cetanas/macos-mail-mcp/issues/54#issuecomment-5505361493), with the matcher and the policy question it raises.

## Changes

- **State** now names #54 and #58, says #54 was open and unread, and drops the "#59 is unmerged" self-reference, which #59 merging made stale.
- **Open questions** — the lockfile question is now attributed to #54 rather than posed fresh, and a second entry records that #54 and #58 interact: fixing #58 alone stops Dependabot bumps dying red and starts them sailing through #54's hole instead, so #54's policy question wants settling first.
- **A process note** — listing open pull requests is not listing open work. Same shape as the "no open pull requests" line #59 already corrected: written from a listing that was true when it ran.
- **Next action** is now #54 first, then #58.

## Verification

`npm test`: 536 passed / 51 skipped across 29 files. No source, workflow or test file changes in this diff — the full recipe ran green on this tree at #59 and nothing outside the handoff moved since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw)_