### PR TITLE
fix(ci): a Copilot round that reviewed nothing is not a review (#54)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -28,7 +28,17 @@
 # `review_requested` event is ever recorded — so all three expired red and no push could have
 # changed that. Not a token problem; this job's own log reports `PullRequests: write`. Requested
 # under a user-scoped token the same three drew a round in five seconds. Until #58 settles the
-# mechanism, a Dependabot pull request needs the round requested by hand and this job re-run.
+# mechanism, a Dependabot pull request needs the round requested by hand and this job re-run. What
+# is fixed is the log: the job no longer calls an unconfirmed request a success.
+#
+# ## A round is not a review just because it arrived (#54)
+#
+# Copilot submits a review in two cases where nobody looked, and the check counted both. They get
+# different answers, because only one of them can be fixed by asking again: an error round is
+# transient and the job keeps waiting, while "wasn't able to review any files" — what Copilot
+# returns for a lockfile-only diff — is permanent for that diff and reports `not-owed`, the same
+# state as a draft. Waiting on it instead would end red on every Dependabot bump with no way to
+# merge, this check being required under `enforce_admins`.
 #
 # ## `pull_request_review` is deliberately not a trigger
 #

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -34,11 +34,21 @@
 # ## A round is not a review just because it arrived (#54)
 #
 # Copilot submits a review in two cases where nobody looked, and the check counted both. They get
-# different answers, because only one of them can be fixed by asking again: an error round is
-# transient and the job keeps waiting, while "wasn't able to review any files" — what Copilot
-# returns for a lockfile-only diff — is permanent for that diff and reports `not-owed`, the same
-# state as a draft. Waiting on it instead would end red on every Dependabot bump with no way to
-# merge, this check being required under `enforce_admins`.
+# different answers, because only one of them can be fixed by asking again:
+#
+#   * an error round is transient — the job keeps waiting, and asks again;
+#   * "wasn't able to review any files", what Copilot returns for a lockfile-only diff, is
+#     permanent for that diff. No round is coming, so the review that is owed is a person's: the
+#     job waits for a human review of that head and asks Copilot for nothing.
+#
+# So a Dependabot lockfile bump costs one human review per bump, deliberately. A lockfile is where
+# a supply-chain change arrives, which is the diff least worth waving through, and the alternative
+# considered — exempting it outright — is the same gate with nobody looking.
+#
+# **Any human review counts, not only an approval**, and that is a deadlock guard rather than
+# laxity: GitHub forbids approving your own pull request, so an APPROVED-only rule would make a
+# maintainer-authored lockfile change unmergeable by anyone here. A `COMMENTED` review is allowed
+# on your own pull request, so the rule stays satisfiable in every case.
 #
 # ## `pull_request_review` is deliberately not a trigger
 #

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -85,6 +85,52 @@ export function hasPendingRequest(nodes) {
 }
 
 /**
+ * Bodies that are a Copilot round arriving with **no review in it** (#54).
+ *
+ * A round is the gate's proxy for "somebody looked at this tree". Copilot submits a review in two
+ * cases where nobody looked, and `classifyRound` counted both as `landed` until now — so the merge
+ * gate was satisfied by the absence of a review, which is the thing it was built to prevent.
+ *
+ * The two are **not the same failure** and do not get the same answer, which is the half #54 did
+ * not have when it was filed:
+ *
+ *   * `DECLINED_DIFF` — *"Copilot wasn't able to review any files in this pull request."* Returned
+ *     for a diff Copilot will not read; measured on #55 and #56, both `package-lock.json`-only, and
+ *     both merged on it. **Re-requesting cannot fix this** — the diff will still be a lockfile — so
+ *     waiting would burn the budget and end red on every Dependabot bump, forever. `not-owed`.
+ *   * `ERRORED` — *"Copilot encountered an error and was unable to review this pull request."*
+ *     Transient; #53 got a real verdict from a re-request two minutes later. `awaited`, which is
+ *     also what makes `awaitRound` ask again.
+ *
+ * Matching a vendor's prose is brittle and is the right trade anyway: the alternative is a gate
+ * that silently accepts nothing. Loose enough to survive rewording, and the day a string changes
+ * the failure is a **red** gate rather than a green one, because an unmatched body falls through
+ * to `landed` only if it is a real round — and a reworded apology reaching `landed` is the
+ * behaviour we already had. Ordered specific-first: `DECLINED_DIFF` is checked before `ERRORED` so
+ * a future *"Copilot was unable to review any files"* lands in the right one.
+ */
+export const DECLINED_DIFF = /able to review any files/i;
+
+/** @see DECLINED_DIFF */
+export const ERRORED = /unable to review/i;
+
+/**
+ * Does this round's body say Copilot did not review anything?
+ *
+ * Guards the type rather than assuming it: `body` is absent on some review payloads and `null` on
+ * others, and `String(null).match()` would happily test the text "null".
+ *
+ * @param {unknown} body
+ * @returns {"declined"|"errored"|null} null when the body reads as an actual review
+ */
+export function emptyRound(body) {
+  if (typeof body !== "string" || body === "") return null;
+  if (DECLINED_DIFF.test(body)) return "declined";
+  if (ERRORED.test(body)) return "errored";
+  return null;
+}
+
+/**
  * @param {{reviews: Array<object>, head: string, draft?: boolean}} input
  * @returns {{state: "landed"|"awaited"|"not-owed", reason: string}}
  */
@@ -107,10 +153,37 @@ export function classifyRound({ reviews, head, draft = false }) {
   const onHead = byCopilot.filter((r) => r?.commit_id === head);
   const short = head.slice(0, 8);
 
-  if (onHead.length > 0) {
+  /*
+   * A round that reviewed nothing does not count as one (#54). Split before deciding, and let a
+   * real round win over an empty one on the same head — that is #53's exact sequence, where an
+   * error round and the genuine verdict both carried `commit_id: 6313d73e`.
+   */
+  const real = onHead.filter((r) => emptyRound(r?.body) === null);
+  const declined = onHead.filter((r) => emptyRound(r?.body) === "declined");
+
+  if (real.length > 0) {
     return {
       state: "landed",
-      reason: `${onHead.length} Copilot round(s) on ${short}, the commit being merged`,
+      reason: `${real.length} Copilot round(s) on ${short}, the commit being merged`,
+    };
+  }
+
+  if (declined.length > 0) {
+    return {
+      state: "not-owed",
+      // Not `awaited`: no re-request changes the diff, so waiting here ends red on every
+      // lockfile-only pull request. Stated as an exemption rather than reached by accident,
+      // which is the difference from what this did before.
+      reason: `Copilot declined to read the diff on ${short} — no round is owed for it`,
+    };
+  }
+
+  if (onHead.length > 0) {
+    return {
+      state: "awaited",
+      // The error case. Naming it separately is the point: a bare "no round yet" here would
+      // describe a round that arrived and said it had failed.
+      reason: `${onHead.length} Copilot round(s) on ${short}, all of them errors — waiting for a real one`,
     };
   }
 
@@ -220,9 +293,10 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  *
  * So the failing combination is a bot-authored pull request asked by the Actions token, and which
  * side GitHub keys on is not established. Until it is, a Dependabot pull request needs the round
- * requested by hand and the job re-run. #58 has the controls and the suggested fix — re-checking
- * `isRoundPending()` after the mutation returns, so a request that did not take says so instead of
- * reporting success. That is a behaviour change to a required check, so it is not made here.
+ * requested by hand and the job re-run; #58 has the controls. The **diagnosis** is fixed — see
+ * `describeRequest`, which re-checks `isRoundPending()` after the mutation and refuses to call an
+ * unconfirmed request a success. The **mechanism** is not: this still cannot make GitHub honour the
+ * request, so #58 stays open and the manual step stands.
  *
  * I/O is injected so the loop is testable without a network or a clock.
  *
@@ -278,7 +352,7 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
         // right answer is the one the check always had: wait, and let the budget decide.
         try {
           await requestRound();
-          log(`requested: no round was on order, asked ${COPILOT_REVIEWER} for one`);
+          log(await describeRequest(isRoundPending));
         } catch (err) {
           log(`could not request a round (${describeError(err)}) — waiting anyway`);
         }
@@ -298,6 +372,48 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
     log(`waiting: ${result.reason}`);
     await sleep(pollMs);
     waited += pollMs;
+  }
+}
+
+/**
+ * What to log after a request that did not throw (#58).
+ *
+ * The old line said `requested: no round was on order, asked … for one` on any resolved mutation,
+ * and on a Dependabot pull request that is a lie: measured on #55, #56 and #57, `requestReviews`
+ * resolves, **no `review_requested` event is ever recorded**, and the check expires red ten
+ * minutes later with a success line at the top of the log. Not a permissions problem — that job's
+ * own log reports `PullRequests: write`. A success code for an action that did not happen is the
+ * failure this repository has a principle about, and it had reappeared inside the code written to
+ * fix it.
+ *
+ * So the request is checked rather than assumed. **The check is not conclusive and does not claim
+ * to be**: a request that Copilot picks up immediately also reads as "nothing pending" — measured
+ * on #49, where the pending request was cleared before the job's first poll. Both readings are in
+ * the line, with the one that matters attached to the outcome that distinguishes them, because a
+ * reader who is looking at this log at all is looking at a run that expired.
+ *
+ * A failure to check is not evidence either way and says so, rather than picking the reassuring
+ * reading.
+ *
+ * @param {(() => Promise<boolean>) | undefined} isRoundPending
+ * @returns {Promise<string>}
+ */
+export async function describeRequest(isRoundPending) {
+  if (!isRoundPending) return `requested: asked ${COPILOT_REVIEWER} for a round`;
+  try {
+    if (await isRoundPending()) {
+      return `requested: asked ${COPILOT_REVIEWER} for a round, and it is on order`;
+    }
+    return (
+      `requested ${COPILOT_REVIEWER} and the mutation succeeded, but nothing is on order a moment ` +
+      `later — either Copilot took it up already, or the request did not take (#58). If this run ` +
+      `expires red, it was the second.`
+    );
+  } catch (err) {
+    return (
+      `requested: asked ${COPILOT_REVIEWER} for a round, and could not confirm it landed ` +
+      `(${describeError(err)})`
+    );
   }
 }
 

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -127,6 +127,16 @@ export const ERRORED = /unable to review/i;
  * catches the ones that carry a login and no type; and Copilot is checked by name because it
  * appears under four spellings, one of which — `Copilot` — has neither marker.
  *
+ * **`type` is accepted only as the literal `"User"`, not as "anything but `Bot`."** The set is open
+ * — REST also returns `Organization`, GraphQL adds `Mannequin` — so a not-`Bot` test reads every
+ * future member as a person by default, and this predicate is the whole gate on the declined-diff
+ * path. An unknown type is refused rather than waved through; the cost of being wrong that way is a
+ * review that has to be re-submitted, against a merge with nobody having looked. _(Raised by
+ * Copilot on #61.)_
+ *
+ * A **missing** `type` is still tolerated, because a trimmed payload carrying only a login is the
+ * ordinary shape in this repository's own fixtures, and the two name checks above still apply.
+ *
  * @param {unknown} user a review's `user` object
  */
 export function isHumanReviewer(user) {
@@ -134,7 +144,8 @@ export function isHumanReviewer(user) {
   if (typeof login !== "string" || login === "") return false;
   if (isCopilotLogin(login)) return false;
   if (login.toLowerCase().endsWith("[bot]")) return false;
-  return /** @type {any} */ (user)?.type !== "Bot";
+  const type = /** @type {any} */ (user)?.type;
+  return type === undefined || type === null ? true : type === "User";
 }
 
 /**
@@ -455,9 +466,9 @@ export async function describeRequest(isRoundPending) {
       return `requested: asked ${COPILOT_REVIEWER} for a round, and it is on order`;
     }
     return (
-      `requested ${COPILOT_REVIEWER} and the mutation succeeded, but nothing is on order a moment ` +
-      `later — either Copilot took it up already, or the request did not take (#58). If this run ` +
-      `expires red, it was the second.`
+      `requested: asked ${COPILOT_REVIEWER}, the mutation succeeded, and nothing is on order a ` +
+      `moment later — either Copilot took it up already, or the request did not take (#58). If ` +
+      `this run expires red, it was the second.`
     );
   } catch (err) {
     return (

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -97,7 +97,8 @@ export function hasPendingRequest(nodes) {
  *   * `DECLINED_DIFF` — *"Copilot wasn't able to review any files in this pull request."* Returned
  *     for a diff Copilot will not read; measured on #55 and #56, both `package-lock.json`-only, and
  *     both merged on it. **Re-requesting cannot fix this** — the diff will still be a lockfile — so
- *     waiting would burn the budget and end red on every Dependabot bump, forever. `not-owed`.
+ *     the round that is owed is a person's. Satisfied by a human review on the head, and `awaited`
+ *     until there is one. See `isHumanReviewer`.
  *   * `ERRORED` — *"Copilot encountered an error and was unable to review this pull request."*
  *     Transient; #53 got a real verdict from a re-request two minutes later. `awaited`, which is
  *     also what makes `awaitRound` ask again.
@@ -113,6 +114,28 @@ export const DECLINED_DIFF = /able to review any files/i;
 
 /** @see DECLINED_DIFF */
 export const ERRORED = /unable to review/i;
+
+/**
+ * Is this review a person's?
+ *
+ * Only consulted where Copilot has declined to read the diff, and there the whole gate rests on it:
+ * a bot slipping through this predicate would satisfy the check with nobody having looked, which is
+ * the defect #54 is about, one layer down.
+ *
+ * Three ways an account can fail to be a person, because one is not enough. `type` is what the API
+ * means to say and is trusted first; it is absent from trimmed payloads, so the `[bot]` suffix
+ * catches the ones that carry a login and no type; and Copilot is checked by name because it
+ * appears under four spellings, one of which — `Copilot` — has neither marker.
+ *
+ * @param {unknown} user a review's `user` object
+ */
+export function isHumanReviewer(user) {
+  const login = /** @type {any} */ (user)?.login;
+  if (typeof login !== "string" || login === "") return false;
+  if (isCopilotLogin(login)) return false;
+  if (login.toLowerCase().endsWith("[bot]")) return false;
+  return /** @type {any} */ (user)?.type !== "Bot";
+}
 
 /**
  * Does this round's body say Copilot did not review anything?
@@ -132,7 +155,7 @@ export function emptyRound(body) {
 
 /**
  * @param {{reviews: Array<object>, head: string, draft?: boolean}} input
- * @returns {{state: "landed"|"awaited"|"not-owed", reason: string}}
+ * @returns {{state: "landed"|"awaited"|"not-owed", reason: string, awaiting?: "human"}}
  */
 export function classifyRound({ reviews, head, draft = false }) {
   if (draft) {
@@ -152,6 +175,9 @@ export function classifyRound({ reviews, head, draft = false }) {
   const byCopilot = list.filter((r) => isCopilotLogin(r?.user?.login));
   const onHead = byCopilot.filter((r) => r?.commit_id === head);
   const short = head.slice(0, 8);
+  // Every review describing the head, Copilot's and everyone else's — the declined branch below is
+  // the one place a non-Copilot review decides the answer.
+  const allOnHead = list.filter((r) => r?.commit_id === head);
 
   /*
    * A round that reviewed nothing does not count as one (#54). Split before deciding, and let a
@@ -169,12 +195,31 @@ export function classifyRound({ reviews, head, draft = false }) {
   }
 
   if (declined.length > 0) {
+    /*
+     * Copilot will not read this diff, so no re-request produces a round and the only reviewer
+     * left is a person. The gate holds rather than exempting the pull request: a lockfile is where
+     * a supply-chain change arrives, which is the diff least worth waving through.
+     *
+     * **Any human review on the head counts, not only an approval**, and that is a deadlock guard
+     * rather than laxity. GitHub forbids approving your own pull request, so an APPROVED-only rule
+     * would make a maintainer-authored lockfile change unmergeable by anyone — the sole maintainer
+     * cannot approve it and there is nobody else. A `COMMENTED` review is allowed on your own pull
+     * request, so the rule stays satisfiable in every case while still costing a person a look and
+     * a statement on the record against this exact tree.
+     */
+    const humans = allOnHead.filter((r) => isHumanReviewer(r?.user));
+    if (humans.length > 0) {
+      return {
+        state: "landed",
+        reason: `Copilot declined to read the diff on ${short}; ${humans.length} human review(s) on it`,
+      };
+    }
     return {
-      state: "not-owed",
-      // Not `awaited`: no re-request changes the diff, so waiting here ends red on every
-      // lockfile-only pull request. Stated as an exemption rather than reached by accident,
-      // which is the difference from what this did before.
-      reason: `Copilot declined to read the diff on ${short} — no round is owed for it`,
+      state: "awaited",
+      // `human`, so the loop asks Copilot for nothing here — another round would arrive declining
+      // the same diff, and the log would name the wrong thing as missing.
+      awaiting: "human",
+      reason: `Copilot declined to read the diff on ${short} — waiting for a human review of it`,
     };
   }
 
@@ -324,7 +369,12 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
       return { ...result, polls };
     }
 
-    if (!asked && requestRound) {
+    /*
+     * Nothing to ask for when the missing reviewer is a person: another Copilot round would arrive
+     * declining the same diff, and the log would announce a request for the one thing already
+     * known not to be coming.
+     */
+    if (!asked && requestRound && result.awaiting !== "human") {
       asked = true;
 
       /*

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -520,8 +520,13 @@ describe("awaitRound requesting the round (#44)", () => {
   });
 
   /*
-   * A round that reviewed nothing ends the wait as `not-owed` rather than burning the budget —
-   * the #54 half, exercised through the loop rather than only through the classifier.
+   * The #54 half through the loop rather than only through the classifier. A declined diff does
+   * **not** end the wait: the check stays `awaited` for a human review of that head and expires
+   * red without one, which is the point of it. What ends early is the asking — see below.
+   *
+   * _(This comment described the `not-owed` exemption an earlier revision of this branch had, and
+   * survived the switch to requiring a human review. Raised by Copilot on #61; a test read as a
+   * spec is exactly where a stale comment does its damage.)_
    */
   const DECLINED_ON_HEAD = {
     user: { login: "Copilot" },

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import { parse } from "yaml";
 import {
   classifyRound,
+  emptyRound,
+  describeRequest,
+  DECLINED_DIFF,
+  ERRORED,
   isCopilotLogin,
   hasPendingRequest,
   describeError,
@@ -105,6 +109,154 @@ describe("classifyRound", () => {
       classifyRound({ reviews: undefined as unknown as [], head: HEAD }).state
     ).toBe("awaited");
     expect(classifyRound({ reviews: [{} as never], head: HEAD }).state).toBe("awaited");
+  });
+});
+
+/**
+ * #54 — a Copilot round that contains no review is not a review.
+ *
+ * The bodies are the ones GitHub actually sent, not paraphrases: the first was quoted on #54 from
+ * the round that satisfied the gate on #53, the second measured on #55 and #56, which merged on it.
+ * Paraphrasing them here would test the matcher against my memory of the string rather than the
+ * string, which is the whole defect one level up.
+ */
+const ERROR_BODY =
+  "Copilot encountered an error and was unable to review this pull request. " +
+  "You can try again by re-requesting a review.";
+const DECLINED_BODY = "Copilot wasn't able to review any files in this pull request.";
+const REAL_BODY = "### 🟢 Approval recommended\n\nThe change is a straightforward SHA-pin bump.";
+
+/** As `review`, plus the body — which is what decides whether a round is a review at all. */
+const round = (login: string, commit_id: string, body: string) => ({
+  user: { login },
+  commit_id,
+  body,
+});
+
+describe("emptyRound (#54)", () => {
+  it("names the declined-diff body, which no re-request can fix", () => {
+    expect(emptyRound(DECLINED_BODY)).toBe("declined");
+  });
+
+  it("names the error body, which a re-request can", () => {
+    expect(emptyRound(ERROR_BODY)).toBe("errored");
+  });
+
+  it("passes a real verdict through", () => {
+    expect(emptyRound(REAL_BODY)).toBe(null);
+  });
+
+  /*
+   * The two patterns must not both match one body, or the ordering in `classifyRound` decides the
+   * answer by accident. "wasn't able to review" does not contain "unable to review" — asserted
+   * rather than reasoned about, because that is a claim about a regex and regexes are checkable.
+   */
+  it("keeps the two patterns disjoint on the measured bodies", () => {
+    expect(ERRORED.test(DECLINED_BODY)).toBe(false);
+    expect(DECLINED_DIFF.test(ERROR_BODY)).toBe(false);
+  });
+
+  /*
+   * The specific-first ordering exists for a rewording that has not happened yet, so this is the
+   * only assertion here testing a string GitHub has never sent. It is worth its keep: it is what
+   * stops the ordering being silently rearranged.
+   */
+  it("reads a hypothetical 'was unable to review any files' as declined, not errored", () => {
+    expect(emptyRound("Copilot was unable to review any files in this pull request.")).toBe(
+      "declined"
+    );
+  });
+
+  it("treats a missing or empty body as a real round rather than throwing", () => {
+    expect(emptyRound(undefined)).toBe(null);
+    expect(emptyRound(null)).toBe(null);
+    expect(emptyRound("")).toBe(null);
+    expect(emptyRound(42)).toBe(null);
+  });
+});
+
+describe("classifyRound on rounds that reviewed nothing (#54)", () => {
+  /*
+   * The regression. Before this, `classifyRound` reported `landed` here and the gate went green
+   * over a pull request nothing had reviewed — measured on #53, where it nearly merged.
+   */
+  it("does not count an error round as landed", () => {
+    const result = classifyRound({ reviews: [round("Copilot", HEAD, ERROR_BODY)], head: HEAD });
+    expect(result.state).toBe("awaited");
+    expect(result.reason).toMatch(/all of them errors/);
+  });
+
+  /*
+   * `not-owed` rather than `awaited`, and the distinction is load-bearing: `copilot-reviewed` is a
+   * required check under `enforce_admins`, so waiting here would end red on every lockfile-only
+   * Dependabot bump with no way to merge it short of turning off branch protection.
+   */
+  it("treats a declined diff as no round being owed", () => {
+    const result = classifyRound({ reviews: [round("Copilot", HEAD, DECLINED_BODY)], head: HEAD });
+    expect(result.state).toBe("not-owed");
+    expect(result.reason).toMatch(/declined to read the diff/);
+  });
+
+  /*
+   * #53's exact sequence: Copilot errored at 17:00:46Z and delivered the real verdict at 18:53:00Z,
+   * both carrying `commit_id: 6313d73e`. The real one has to win regardless of order in the list.
+   */
+  it("lets a real round win over an empty one on the same head", () => {
+    for (const reviews of [
+      [round("Copilot", HEAD, ERROR_BODY), round("Copilot", HEAD, REAL_BODY)],
+      [round("Copilot", HEAD, REAL_BODY), round("Copilot", HEAD, ERROR_BODY)],
+    ]) {
+      const result = classifyRound({ reviews, head: HEAD });
+      expect(result.state).toBe("landed");
+      expect(result.reason).toMatch(/^1 Copilot round\(s\)/);
+    }
+  });
+
+  it("still ignores an empty round that describes an older commit", () => {
+    const result = classifyRound({ reviews: [round("Copilot", OLDER, DECLINED_BODY)], head: HEAD });
+    expect(result.state).toBe("awaited");
+    expect(result.reason).toMatch(/the branch moved/);
+  });
+
+  it("counts only the real rounds in the reason", () => {
+    const reviews = [
+      round("Copilot", HEAD, ERROR_BODY),
+      round("Copilot", HEAD, REAL_BODY),
+      round("Copilot", HEAD, REAL_BODY),
+    ];
+    expect(classifyRound({ reviews, head: HEAD }).reason).toContain("2 Copilot round(s)");
+  });
+});
+
+describe("describeRequest (#58)", () => {
+  it("says the round is on order when the request took", async () => {
+    expect(await describeRequest(async () => true)).toMatch(/on order/);
+  });
+
+  /*
+   * The line that exists for #58. It must name both readings — a request Copilot picked up
+   * instantly looks identical here (measured on #49) — and attach the one that matters to the
+   * outcome that separates them.
+   */
+  it("names both readings when nothing is on order afterwards", async () => {
+    const line = await describeRequest(async () => false);
+    expect(line).toMatch(/did not take \(#58\)/);
+    expect(line).toMatch(/took it up already/);
+    expect(line).toMatch(/expires red/);
+  });
+
+  it("reports a failed confirmation as unknown rather than as either answer", async () => {
+    const line = await describeRequest(async () => {
+      throw new Error("GraphQL -> 403");
+    });
+    expect(line).toMatch(/could not confirm it landed \(GraphQL -> 403\)/);
+    expect(line).not.toMatch(/did not take/);
+    expect(line).not.toMatch(/on order/);
+  });
+
+  it("claims nothing when there is no way to check", async () => {
+    const line = await describeRequest(undefined);
+    expect(line).toBe(`requested: asked ${COPILOT_REVIEWER} for a round`);
   });
 });
 
@@ -233,13 +385,62 @@ describe("awaitRound requesting the round (#44)", () => {
     await awaitRound({
       api: apiWith([]),
       requestRound: s.requestRound,
-      isRoundPending: notPending,
+      // Flips the way a request that takes does: nothing on order before the ask, on order after.
+      isRoundPending: (() => {
+        let asked = false;
+        return async () => (asked ? true : ((asked = true), false));
+      })(),
       sleep: noSleep,
       budgetMs: 0,
       log: s.log,
     });
     expect(s.asked).toBe(1);
     expect(s.lines.some((l) => l.startsWith("requested:"))).toBe(true);
+  });
+
+  /*
+   * #58 — the same call, on a pull request where the mutation resolves and records nothing.
+   * Measured on #55, #56 and #57. Before this the log read `requested: no round was on order,
+   * asked … for one` and the run then expired red ten minutes later with a success line at the
+   * top, which is the opposite of a clue.
+   */
+  it("says so when the request resolves and leaves nothing on order", async () => {
+    const s = spy();
+    await awaitRound({
+      api: apiWith([]),
+      requestRound: s.requestRound,
+      isRoundPending: notPending,
+      sleep: noSleep,
+      budgetMs: 0,
+      log: s.log,
+    });
+    expect(s.asked).toBe(1);
+    expect(s.lines.some((l) => /did not take \(#58\)/.test(l))).toBe(true);
+  });
+
+  /*
+   * A round that reviewed nothing ends the wait as `not-owed` rather than burning the budget —
+   * the #54 half, exercised through the loop rather than only through the classifier.
+   */
+  it("stops on a declined diff instead of waiting for a round that cannot come", async () => {
+    const s = spy();
+    const result = await awaitRound({
+      api: apiWith([
+        {
+          user: { login: "Copilot" },
+          commit_id: HEAD,
+          body: "Copilot wasn't able to review any files in this pull request.",
+        },
+      ]),
+      requestRound: s.requestRound,
+      isRoundPending: notPending,
+      sleep: noSleep,
+      budgetMs: 0,
+      log: s.log,
+    });
+    expect(result.state).toBe("not-owed");
+    expect(result.polls).toBe(1);
+    expect(s.asked).toBe(0);
   });
 
   // The ordinary case: the ruleset requested one a second after the pull request opened. Asking

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 import {
   classifyRound,
   emptyRound,
+  isHumanReviewer,
   describeRequest,
   DECLINED_DIFF,
   ERRORED,
@@ -187,14 +188,60 @@ describe("classifyRound on rounds that reviewed nothing (#54)", () => {
   });
 
   /*
-   * `not-owed` rather than `awaited`, and the distinction is load-bearing: `copilot-reviewed` is a
-   * required check under `enforce_admins`, so waiting here would end red on every lockfile-only
-   * Dependabot bump with no way to merge it short of turning off branch protection.
+   * A diff Copilot will not read still owes a review — a person's. A lockfile is where a
+   * supply-chain change arrives, so it is the diff least worth waving through.
    */
-  it("treats a declined diff as no round being owed", () => {
+  it("waits for a human when Copilot declined the diff", () => {
     const result = classifyRound({ reviews: [round("Copilot", HEAD, DECLINED_BODY)], head: HEAD });
-    expect(result.state).toBe("not-owed");
-    expect(result.reason).toMatch(/declined to read the diff/);
+    expect(result.state).toBe("awaited");
+    expect(result.awaiting).toBe("human");
+    expect(result.reason).toMatch(/waiting for a human review/);
+  });
+
+  it("is satisfied by a human review of the same head", () => {
+    const result = classifyRound({
+      reviews: [
+        round("Copilot", HEAD, DECLINED_BODY),
+        { user: { login: "marius-cetanas", type: "User" }, commit_id: HEAD, body: "lgtm" },
+      ],
+      head: HEAD,
+    });
+    expect(result.state).toBe("landed");
+    expect(result.reason).toMatch(/1 human review\(s\)/);
+  });
+
+  it("does not accept a human review of an earlier commit", () => {
+    const result = classifyRound({
+      reviews: [
+        round("Copilot", HEAD, DECLINED_BODY),
+        { user: { login: "marius-cetanas", type: "User" }, commit_id: OLDER, body: "lgtm" },
+      ],
+      head: HEAD,
+    });
+    expect(result.state).toBe("awaited");
+    expect(result.awaiting).toBe("human");
+  });
+
+  /*
+   * The gate rests entirely on this predicate in the declined case, so a bot must not pass it.
+   * Dependabot authors the pull requests this branch exists for.
+   *
+   * Copilot is deliberately not in this list: a Copilot review with a real body on the head is a
+   * genuine round and *should* land, declined sibling or not. That it is not a human reviewer is
+   * asserted in `isHumanReviewer` instead, which is where the claim belongs.
+   */
+  it("does not accept a bot review as the human one", () => {
+    for (const user of [
+      { login: "dependabot[bot]", type: "Bot" },
+      { login: "some-app[bot]" },
+      { login: "renovate", type: "Bot" },
+    ]) {
+      const result = classifyRound({
+        reviews: [round("Copilot", HEAD, DECLINED_BODY), { user, commit_id: HEAD, body: "x" }],
+        head: HEAD,
+      });
+      expect(result.state, user.login).toBe("awaited");
+    }
   });
 
   /*
@@ -225,6 +272,28 @@ describe("classifyRound on rounds that reviewed nothing (#54)", () => {
       round("Copilot", HEAD, REAL_BODY),
     ];
     expect(classifyRound({ reviews, head: HEAD }).reason).toContain("2 Copilot round(s)");
+  });
+});
+
+describe("isHumanReviewer", () => {
+  it("accepts a person", () => {
+    expect(isHumanReviewer({ login: "marius-cetanas", type: "User" })).toBe(true);
+    expect(isHumanReviewer({ login: "marius-cetanas" })).toBe(true);
+  });
+
+  it("rejects a bot by type, by suffix, and by name", () => {
+    expect(isHumanReviewer({ login: "someone", type: "Bot" })).toBe(false);
+    expect(isHumanReviewer({ login: "dependabot[bot]" })).toBe(false);
+    // The spelling that carries neither marker, which is why the name check exists.
+    expect(isHumanReviewer({ login: "Copilot" })).toBe(false);
+  });
+
+  it("rejects a missing or malformed user rather than throwing", () => {
+    expect(isHumanReviewer(undefined)).toBe(false);
+    expect(isHumanReviewer(null)).toBe(false);
+    expect(isHumanReviewer({})).toBe(false);
+    expect(isHumanReviewer({ login: "" })).toBe(false);
+    expect(isHumanReviewer({ login: 42 })).toBe(false);
   });
 });
 
@@ -422,15 +491,37 @@ describe("awaitRound requesting the round (#44)", () => {
    * A round that reviewed nothing ends the wait as `not-owed` rather than burning the budget —
    * the #54 half, exercised through the loop rather than only through the classifier.
    */
-  it("stops on a declined diff instead of waiting for a round that cannot come", async () => {
+  const DECLINED_ON_HEAD = {
+    user: { login: "Copilot" },
+    commit_id: HEAD,
+    body: "Copilot wasn't able to review any files in this pull request.",
+  };
+
+  /*
+   * Asking again would request the one thing already known not to be coming, and would put
+   * "asked Copilot for a round" in a log whose actual problem is that no person has looked.
+   */
+  it("asks Copilot for nothing when the missing reviewer is a person", async () => {
+    const s = spy();
+    const result = await awaitRound({
+      api: apiWith([DECLINED_ON_HEAD]),
+      requestRound: s.requestRound,
+      isRoundPending: notPending,
+      sleep: noSleep,
+      budgetMs: 0,
+      log: s.log,
+    });
+    expect(result.state).toBe("expired");
+    expect(result.reason).toMatch(/waiting for a human review/);
+    expect(s.asked).toBe(0);
+  });
+
+  it("goes green the moment the human review of that head exists", async () => {
     const s = spy();
     const result = await awaitRound({
       api: apiWith([
-        {
-          user: { login: "Copilot" },
-          commit_id: HEAD,
-          body: "Copilot wasn't able to review any files in this pull request.",
-        },
+        DECLINED_ON_HEAD,
+        { user: { login: "marius-cetanas", type: "User" }, commit_id: HEAD, body: "lgtm" },
       ]),
       requestRound: s.requestRound,
       isRoundPending: notPending,
@@ -438,7 +529,7 @@ describe("awaitRound requesting the round (#44)", () => {
       budgetMs: 0,
       log: s.log,
     });
-    expect(result.state).toBe("not-owed");
+    expect(result.state).toBe("landed");
     expect(result.polls).toBe(1);
     expect(s.asked).toBe(0);
   });

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -288,6 +288,23 @@ describe("isHumanReviewer", () => {
     expect(isHumanReviewer({ login: "Copilot" })).toBe(false);
   });
 
+  /*
+   * The account-type set is open — REST also returns `Organization`, GraphQL adds `Mannequin` — so
+   * "anything but Bot" would read every future member as a person. Refused by default instead.
+   * (Raised by Copilot on #61.)
+   */
+  it("accepts only the literal User when a type is present", () => {
+    expect(isHumanReviewer({ login: "someone", type: "User" })).toBe(true);
+    for (const type of ["Organization", "Mannequin", "EnterpriseUserAccount", "", "user"]) {
+      expect(isHumanReviewer({ login: "someone", type }), type).toBe(false);
+    }
+  });
+
+  it("still tolerates a payload trimmed to a login", () => {
+    expect(isHumanReviewer({ login: "someone", type: undefined })).toBe(true);
+    expect(isHumanReviewer({ login: "someone", type: null })).toBe(true);
+  });
+
   it("rejects a missing or malformed user rather than throwing", () => {
     expect(isHumanReviewer(undefined)).toBe(false);
     expect(isHumanReviewer(null)).toBe(false);
@@ -321,6 +338,18 @@ describe("describeRequest (#58)", () => {
     expect(line).toMatch(/could not confirm it landed \(GraphQL -> 403\)/);
     expect(line).not.toMatch(/did not take/);
     expect(line).not.toMatch(/on order/);
+  });
+
+  it("keeps the `requested:` prefix on every branch", async () => {
+    const lines = [
+      await describeRequest(async () => true),
+      await describeRequest(async () => false),
+      await describeRequest(async () => {
+        throw new Error("boom");
+      }),
+      await describeRequest(undefined),
+    ];
+    for (const line of lines) expect(line, line).toMatch(/^requested: /);
   });
 
   it("claims nothing when there is no way to check", async () => {
@@ -485,6 +514,9 @@ describe("awaitRound requesting the round (#44)", () => {
     });
     expect(s.asked).toBe(1);
     expect(s.lines.some((l) => /did not take \(#58\)/.test(l))).toBe(true);
+    // Every line this function emits shares the prefix, so prefix scanning stays meaningful.
+    // (Raised by Copilot on #61.)
+    expect(s.lines.every((l) => l.startsWith("requested:") || l.startsWith("waiting:"))).toBe(true);
   });
 
   /*


### PR DESCRIPTION
Closes #54. Addresses the diagnosis half of #58, which **stays open** — see below.

## The defect

`classifyRound` counted any Copilot round on the head as `landed`. Copilot submits a review in two cases where nobody looked, so the merge gate was satisfied by the absence of a review — the thing #25/#37 built it to prevent. Not hypothetical, twice:

| | body | outcome |
|---|---|---|
| #53 | *"Copilot encountered an error and was unable to review this pull request."* | gate green, nearly merged on it |
| #55, #56 | *"Copilot wasn't able to review any files in this pull request."* | gate green, **merged on it** |

The second is the one #54 did not know about, and it changes the issue's urgency. #54 judged the failure rare — *"Requires Copilot to error, which has happened once here."* The lockfile body needs nothing to go wrong: it is what Copilot returns for a diff it will not read, and Dependabot produces one weekly.

## The two bodies get different answers

Only one of them can be fixed by asking again, which is what splits them:

- **`ERRORED`** — *"…encountered an error and was unable to review…"* → **`awaited`**, which is also what makes the loop ask again. #53 got a real verdict from a re-request two minutes later.
- **`DECLINED_DIFF`** — *"…wasn't able to review any files…"* → no round is ever coming, so **the review that is owed is a person's**. The job waits for a human review of that head, and asks Copilot for nothing — another round would arrive declining the same diff, and the log would name the wrong thing as missing.

A real round wins over an empty one on the same head, in either list order — #53's exact sequence, where the error round and the genuine verdict both carried `commit_id: 6313d73e`.

## A lockfile bump now costs one human review

Deliberate, and chosen over the alternative. Exempting a diff Copilot will not read (`not-owed`, the way a draft is exempt) was the first implementation here and is the wrong trade: a lockfile is where a supply-chain change arrives, which is the diff least worth waving through, and the exemption is the same gate with nobody looking. The cost is one review per Dependabot bump, weekly.

**Any human review counts, not only an approval**, and that is a deadlock guard rather than laxity. GitHub forbids approving your own pull request, so an APPROVED-only rule would leave a maintainer-authored lockfile change unmergeable by anyone here — the sole maintainer cannot approve it and there is nobody else. A `COMMENTED` review is allowed on your own pull request, so the rule stays satisfiable in every case while still costing a person a look and a statement on the record against that exact tree.

`isHumanReviewer` rejects a bot three ways, because one is not enough: `type` when the payload carries it, the `[bot]` suffix when it does not, and Copilot by name, since one of its four spellings (`Copilot`) carries neither marker. The gate rests entirely on this predicate in the declined case.

## The #58 half, and why it does not close it

`describeRequest` re-checks `isRoundPending()` after the mutation returns and refuses to call an unconfirmed request a success. Before this, a Dependabot run logged `requested: no round was on order, asked … for one` and then expired red ten minutes later — a success line at the top of the log for an action that never happened.

The check is **not conclusive and the message does not pretend otherwise**: a request Copilot takes up instantly also reads as "nothing pending" (measured on #49). So the line names both readings and attaches the one that matters to the outcome that separates them:

> requested … and the mutation succeeded, but nothing is on order a moment later — either Copilot took it up already, or the request did not take (#58). If this run expires red, it was the second.

A failed confirmation reports unknown rather than picking the reassuring reading.

**#58 stays open.** This makes the failure legible; it cannot make GitHub honour the request.

## Sequencing

This is the order argued on [#58](https://github.com/marius-cetanas/macos-mail-mcp/issues/58#issuecomment-5505363432): close the fail-open first, because fixing #58's mechanism would route every Dependabot bump onto that path automatically.

## One release note

The title is `fix(ci):`, which `next-version.mjs` ranks **patch** — so this alone would derive a patch release for a change that ships nothing, `src/` being untouched. That is the wart `CLAUDE.md` already names, and `bump` is the override. Deliberately not `fix(ci)!`: the `!` ranks major, which would be plainly wrong here.

## Verification

`npm run build && npm run test:coverage && npm audit --audit-level=high`: **560 passed / 51 skipped across 29 files** (24 new assertions), 100% statements (263/263), branches (100/100), functions (64/64) and lines (262/262) on `src/`, 0 vulnerabilities. `npx portulan compile --check` GREEN.

The new assertions use the bodies GitHub actually sent, quoted from #54 and measured on #55/#56 — paraphrasing them would test the matcher against my memory of the string rather than the string, which is the defect one level up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw