### PR TITLE
fix(ci): make the mutation report whether GitHub recorded the request (#58)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -27,9 +27,16 @@
 # Measured on #55, #56 and #57: the mutation is accepted, the job logs that it asked, and no
 # `review_requested` event is ever recorded — so all three expired red and no push could have
 # changed that. Not a token problem; this job's own log reports `PullRequests: write`. Requested
-# under a user-scoped token the same three drew a round in five seconds. Until #58 settles the
-# mechanism, a Dependabot pull request needs the round requested by hand and this job re-run. What
-# is fixed is the log: the job no longer calls an unconfirmed request a success.
+# under a user-scoped token the same three drew a round in five seconds.
+#
+# The mechanism is documented and it is billing attribution: a Copilot review must be charged to a
+# Copilot-licensed account, a manual request by a **user** is attributed to that user, and in the
+# failing cell there is no such account — an app requester is not a user and the author is a bot.
+# GitHub's fix for it is an organization policy on Copilot Business/Enterprise, and this repository
+# is user-owned, so it is not available here. `pull_request_target` does not help: it changes the
+# token, not the actor. Only a user-scoped token would, and that is a stored credential and a
+# gate-map decision. So a Dependabot pull request needs the round requested by hand and this job
+# re-run. See #58 for the citations.
 #
 # ## A round is not a review just because it arrived (#54)
 #

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -54,15 +54,39 @@ this session took timeline archaeology across four pull requests.
 
 ## Open questions *(human-owned)*
 
-- **#58's mechanism.** Measured, it fails only when the pull request's author **and** the requester
-  are both bots; each alone works. Whether GitHub keys on the author, the requesting actor, or the
-  Dependabot token context is not established. The instrumentation above turns the next Dependabot
-  pull request into the experiment, at no cost.
-- **Whether a stored PAT is acceptable** if the mechanism turns out to be requester-keyed. It is the
-  only fix that works under both hypotheses, and it is a real reversal of a stated design property.
+- **Whether a stored user token is acceptable.** Now the only question, and it is a real reversal of
+  a stated design property. See below — the mechanism is no longer open.
 
-**Next action.** Push `ccd4793` and open its pull request. Then #58 waits for the next Dependabot
-bump, which will now diagnose itself.
+## The mechanism is documented, and it is billing attribution
+
+Answered after the above was written, from GitHub's documentation rather than by experiment — so
+the "turns the next bump into the experiment" line above is superseded, and the instrumentation is
+now belt-and-braces rather than the plan.
+
+It is neither the author nor the requester alone, which is why the four-cell matrix looked
+contradictory. A Copilot review has to be **charged to a Copilot-licensed account**: a manual
+request by a *user* is attributed to that user, and a licensed human author covers the automatic
+case. In the failing cell there is no such account — the requester is an app rather than a user,
+and the author is a bot. GitHub's 2026-08-27 changelog names the case exactly, and its remedy is an
+**organization policy on Copilot Business/Enterprise**.
+
+**This repository is user-owned, so that policy does not exist for it.** Three consequences:
+
+- The failure is **structural, not a bug**. No amount of workflow engineering reaches it.
+- **`pull_request_target` would not have worked**, which was my leading candidate. It changes the
+  token and the secret source; it does **not** change the actor, which stays `github-actions[bot]`
+  — still not a user, still nothing to bill. Recorded because it is the plausible fix a future
+  session will otherwise spend a day on.
+- The only mechanism fix left is a **user-scoped token**, i.e. a stored credential, which the
+  release design is built to avoid. Gate-map decision, and the only open question on #58.
+
+Caveat kept deliberately: GitHub documents the attribution rule and does **not** document that a
+request with nothing to bill is dropped *silently*, with no `review_requested` event and no GraphQL
+error. That half is still ours, measured and not confirmed by any source. The citations, their
+provenance, and the docs-vs-inference split are on #58.
+
+**Next action.** #58 needs one decision — stored user token, or keep the manual step. Nothing else
+about it is open.
 
 **Recoverability.** Nothing partial on the remote: every merged pull request is squashed and its
 branch deleted, no tag was pushed, no release was run. The only work not on `main` is `ccd4793` on

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -32,7 +32,9 @@ mutation's own response**.
 The distinction that makes this worth more than the poll added earlier the same session: the poll
 asks again *afterwards* and races Copilot, so "nothing pending" has an innocent reading (Copilot
 already took it up, measured on #49) and the message has to hedge. The mutation's own answer has no
-innocent reading, so that line does not hedge and says the check will expire.
+innocent reading, so that line does not hedge **about what GitHub said** — while staying silent on
+what the run does next, which it cannot know: the job keeps polling, and a round requested by hand
+inside that window still lands and still counts.
 
 **This diagnoses #58; it does not fix it.** Nothing here makes GitHub honour the request. What it
 buys is that the next Dependabot pull request states the failure in one line, where establishing it
@@ -51,6 +53,22 @@ this session took timeline archaeology across four pull requests.
 - **Answered the stop-gate rather than working around it.** It asked for a handoff dated today and
   was right to: four of the session's merges carry this date and the series would have had nothing
   under it.
+
+## The mistake I made five times
+
+Worth recording because it is the session's only repeated one, and it is not a coding mistake.
+
+Every time behaviour changed here, a sentence describing the old behaviour survived the edit —
+`copilot-round.mjs` claiming the ask "fixes both" holes; a test comment describing the `not-owed`
+exemption two lines above assertions contradicting it; a heading scoping a cost to every pull
+request; a log line predicting an expiry the loop had stopped guaranteeing; and this file saying
+that line still predicts it. Copilot found all five. None was found by me re-reading the diff,
+because the sentences were true when written and I read them as ones I had already checked.
+
+The generalisable part: **prose is not covered by the tests that cover the code it describes**, so
+changing behaviour is exactly when its description is least trustworthy and most trusted. The
+cheap habit that would have caught all five is to grep the branch for the claim being invalidated
+rather than only the code, in the same commit that invalidates it.
 
 ## Open questions *(human-owned)*
 

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -1,0 +1,70 @@
+# Handoff — the selection was the diagnosis
+
+Continues [yesterday's handoff](2026-09-01-a-fix-that-never-worked-where-it-was-aimed.md), which
+this session ran past midnight UTC. That file holds the measurements and the reasoning; this one
+holds what happened after them, and is deliberately short where it would otherwise repeat.
+
+**State.** `main` at `94f1c63`, green: **570 passed / 51 skipped across 29 files**, 100%
+statements/branches/functions/lines on `src/`, 0 vulnerabilities, `portulan compile --check` GREEN.
+Merged on this date: **#59** and **#60** (correcting claims the tree contradicted), **#61** (the
+`copilot-reviewed` fix, closing **#54**) and **#62** (the previous handoff's amendment). Published
+version unchanged at **1.3.3**; the next derived release is **1.3.4**, a patch from #61's `fix(ci):`
+subject for a change that ships nothing, `src/` being untouched — the wart `CLAUDE.md` names, with
+`bump` as the override. **Open: #58 only.**
+
+**In flight, committed and not pushed:** `ccd4793`, the #58 diagnosis below. A research agent was
+still running when this was written; its findings are not in here.
+
+## What #58 turned out to need first
+
+The mutation was asking GitHub the wrong question, and had been since it was written:
+
+```
+requestReviews(input:{…}){ pullRequest{ id } }
+```
+
+`id` comes back whether or not the mutation did anything. So the response was discarded, and a
+mutation **accepted and dropped** was indistinguishable from one that worked — which is the entire
+symptom of #58 and cost #55, #56 and #57 a red required check each, under a success line at the top
+of each log. Selecting `reviewRequests` back instead reads the post-mutation state **in the
+mutation's own response**.
+
+The distinction that makes this worth more than the poll added earlier the same session: the poll
+asks again *afterwards* and races Copilot, so "nothing pending" has an innocent reading (Copilot
+already took it up, measured on #49) and the message has to hedge. The mutation's own answer has no
+innocent reading, so that line does not hedge and says the check will expire.
+
+**This diagnoses #58; it does not fix it.** Nothing here makes GitHub honour the request. What it
+buys is that the next Dependabot pull request states the failure in one line, where establishing it
+this session took timeline archaeology across four pull requests.
+
+## Decisions + why
+
+- **`null`, not `false`, for an unfamiliar response shape** — because an absent field is *"this
+  response did not say"*, which is a different claim from *"GitHub says Copilot is not requested"*.
+  Collapsing them would report a defect on any future schema change.
+- **Did not ship a mechanism fix** — the two candidates are not equivalent and the choice is not
+  mine. `pull_request_target` gets a non-Dependabot token but keeps `github-actions[bot]` as the
+  actor, so it helps only if the discriminator is the token context. A user-scoped PAT in Dependabot
+  secrets would work under either discriminator and **introduces a stored credential**, which is
+  exactly what the release design congratulates itself on not having. That is a gate-map decision.
+- **Answered the stop-gate rather than working around it.** It asked for a handoff dated today and
+  was right to: four of the session's merges carry this date and the series would have had nothing
+  under it.
+
+## Open questions *(human-owned)*
+
+- **#58's mechanism.** Measured, it fails only when the pull request's author **and** the requester
+  are both bots; each alone works. Whether GitHub keys on the author, the requesting actor, or the
+  Dependabot token context is not established. The instrumentation above turns the next Dependabot
+  pull request into the experiment, at no cost.
+- **Whether a stored PAT is acceptable** if the mechanism turns out to be requester-keyed. It is the
+  only fix that works under both hypotheses, and it is a real reversal of a stated design property.
+
+**Next action.** Push `ccd4793` and open its pull request. Then #58 waits for the next Dependabot
+bump, which will now diagnose itself.
+
+**Recoverability.** Nothing partial on the remote: every merged pull request is squashed and its
+branch deleted, no tag was pushed, no release was run. The only work not on `main` is `ccd4793` on
+this branch, which is one commit, verified green, and carries no behaviour change beyond a log line
+and a GraphQL selection.

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -366,10 +366,12 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  * citations, and the caveat that GitHub documents the attribution rule without documenting that
  * the request is then dropped with no `review_requested` event.
  *
- * The **diagnosis** is fixed — see
- * `describeRequest`, which re-checks `isRoundPending()` after the mutation and refuses to call an
- * unconfirmed request a success. The **mechanism** is not: this still cannot make GitHub honour the
- * request, so #58 stays open and the manual step stands.
+ * The **diagnosis** is fixed — see `requestRound`, which asks the mutation to return the pull
+ * request's requested reviewers, and `describeRequest`, which reports what that answer said and
+ * falls back to polling `isRoundPending()` only when the mutation reported nothing either way.
+ * Neither calls an unconfirmed request a success. The **mechanism** is not fixed and cannot be
+ * fixed here: no workflow rearrangement supplies an account to bill, so #58 stays open and the
+ * manual step stands.
  *
  * I/O is injected so the loop is testable without a network or a clock.
  *

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -347,9 +347,26 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  * seconds, which is how they were unblocked. The same code path on a human-authored pull request
  * (#49) does record `review_requested by github-actions[bot]`.
  *
- * So the failing combination is a bot-authored pull request asked by the Actions token, and which
- * side GitHub keys on is not established. Until it is, a Dependabot pull request needs the round
- * requested by hand and the job re-run; #58 has the controls. The **diagnosis** is fixed — see
+ * **The mechanism is billing attribution, and it is documented** — neither the author nor the
+ * requester on its own, which is why the matrix looked contradictory. A Copilot review has to be
+ * charged to a Copilot-licensed account. *"If a review is manually requested by another user, the
+ * consumption is attributed to that user instead"* covers the two cells a human requested; a
+ * licensed human author covers the third. In the failing cell there is no such account — the
+ * requester is an app rather than a user, and the author is a bot. GitHub's 2026-08-27 changelog
+ * names exactly this case: *"When a pull request is authored by a bot and requested automatically,
+ * there's no Copilot-licensed account to attribute the review to"*, fixed by an organization
+ * policy on Copilot Business/Enterprise.
+ *
+ * **This repository is user-owned, so that policy does not exist for it.** The failure is
+ * structural rather than a bug, and no workflow rearrangement reaches it: `pull_request_target`
+ * changes the token and the secret source but **not the actor**, which stays `github-actions[bot]`
+ * — still not a user, still nothing to bill. Only a user-scoped token would work, and that means a
+ * stored credential, which is a gate-map decision rather than an implementation one. So a
+ * Dependabot pull request needs the round requested by hand and the job re-run; #58 carries the
+ * citations, and the caveat that GitHub documents the attribution rule without documenting that
+ * the request is then dropped with no `review_requested` event.
+ *
+ * The **diagnosis** is fixed — see
  * `describeRequest`, which re-checks `isRoundPending()` after the mutation and refuses to call an
  * unconfirmed request a success. The **mechanism** is not: this still cannot make GitHub honour the
  * request, so #58 stays open and the manual step stands.
@@ -464,7 +481,7 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
  * `requestRound` that does not report one, which every stub in the suite and any older caller is.
  *
  * @param {(() => Promise<boolean>) | undefined} isRoundPending
- * @param {boolean | null | undefined} recorded what the mutation's own response said, if anything
+ * @param {boolean | null} [recorded] what the mutation's own response said, if anything
  * @returns {Promise<string>}
  */
 export async function describeRequest(isRoundPending, recorded) {
@@ -474,8 +491,8 @@ export async function describeRequest(isRoundPending, recorded) {
   if (recorded === false) {
     return (
       `requested: asked ${COPILOT_REVIEWER}, the mutation succeeded, and GitHub's own response ` +
-      `does not list Copilot among the reviewers — the request did not take (#58). Nothing this ` +
-      `job can do will produce a round; the check will expire.`
+      `does not list Copilot among the pull request's requested reviewers — the request did not ` +
+      `take (#58). Nothing this job can do will produce a round; the check will expire.`
     );
   }
   if (!isRoundPending) return `requested: asked ${COPILOT_REVIEWER} for a round`;

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -412,8 +412,8 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
         // read-only whatever the workflow asks for, so this is expected to fail there — and the
         // right answer is the one the check always had: wait, and let the budget decide.
         try {
-          await requestRound();
-          log(await describeRequest(isRoundPending));
+          const outcome = await requestRound();
+          log(await describeRequest(isRoundPending, outcome?.recorded));
         } catch (err) {
           log(`could not request a round (${describeError(err)}) — waiting anyway`);
         }
@@ -456,10 +456,28 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
  * A failure to check is not evidence either way and says so, rather than picking the reassuring
  * reading.
  *
+ * ## `recorded` outranks the poll, when there is one
+ *
+ * `requestRound` now asks the mutation to return the pull request's reviewers, so GitHub reports
+ * the post-mutation state **in the response to the mutation itself**. That answer is not racing
+ * anything and is preferred whenever it exists; the poll below stays as the fallback for a
+ * `requestRound` that does not report one, which every stub in the suite and any older caller is.
+ *
  * @param {(() => Promise<boolean>) | undefined} isRoundPending
+ * @param {boolean | null | undefined} recorded what the mutation's own response said, if anything
  * @returns {Promise<string>}
  */
-export async function describeRequest(isRoundPending) {
+export async function describeRequest(isRoundPending, recorded) {
+  if (recorded === true) {
+    return `requested: asked ${COPILOT_REVIEWER} for a round, and GitHub recorded it`;
+  }
+  if (recorded === false) {
+    return (
+      `requested: asked ${COPILOT_REVIEWER}, the mutation succeeded, and GitHub's own response ` +
+      `does not list Copilot among the reviewers — the request did not take (#58). Nothing this ` +
+      `job can do will produce a round; the check will expire.`
+    );
+  }
   if (!isRoundPending) return `requested: asked ${COPILOT_REVIEWER} for a round`;
   try {
     if (await isRoundPending()) {
@@ -576,15 +594,40 @@ export function makeGithubIo({ fetch, token, repo, pr }) {
     const { node_id: botId } = await res.json();
     if (!botId) throw new Error(`no node id in the response for ${COPILOT_REVIEWER}`);
 
+    /*
+     * The selection is the diagnosis (#58).
+     *
+     * This used to ask for `pullRequest { id }` — the one field guaranteed to come back whether or
+     * not the mutation did anything — and threw the response away. So a mutation that was accepted
+     * and recorded nothing was indistinguishable from one that worked, which is exactly what
+     * happens on a Dependabot pull request and cost #55, #56 and #57 a red required check each
+     * with a success line at the top of the log.
+     *
+     * Asking for `reviewRequests` back reads the **post-mutation state in the mutation's own
+     * response**, so GitHub answers the question directly rather than being asked again afterwards
+     * and racing Copilot for it.
+     */
     const { id } = await pullRequest("id");
-    return graphql(
+    const data = await graphql(
       `mutation($pullRequestId:ID!,$botIds:[ID!]){
          requestReviews(input:{pullRequestId:$pullRequestId,botIds:$botIds,union:true}){
-           pullRequest{ id }
+           pullRequest{
+             reviewRequests(first:${REVIEWER_PAGE}){
+               nodes{requestedReviewer{... on Bot{login} ... on User{login}}}
+             }
+           }
          }
        }`,
       { pullRequestId: id, botIds: [botId] }
     );
+
+    /*
+     * `null` rather than `false` when the shape is not what we expected: an absent field is "this
+     * response did not say", which is a different claim from "GitHub says Copilot is not
+     * requested", and collapsing the two would report a defect on any future schema change.
+     */
+    const nodes = data?.requestReviews?.pullRequest?.reviewRequests?.nodes;
+    return { recorded: Array.isArray(nodes) ? hasPendingRequest(nodes) : null };
   };
 
   return { api, graphql, isRoundPending, requestRound };

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -480,6 +480,13 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
  * anything and is preferred whenever it exists; the poll below stays as the fallback for a
  * `requestRound` that does not report one, which every stub in the suite and any older caller is.
  *
+ * **It is definite about what GitHub said and not about what happens next**, and the second half is
+ * a correction: an earlier draft ended *"the check will expire"*, which the loop does not
+ * guarantee. The job keeps polling for the rest of its budget, and the documented workaround for
+ * #58 — a user requesting the round by hand — lands inside that window and turns the check green.
+ * Predicting the expiry would have been a confident sentence about a run that had not finished.
+ * _(Raised by Copilot on #63.)_
+ *
  * @param {(() => Promise<boolean>) | undefined} isRoundPending
  * @param {boolean | null} [recorded] what the mutation's own response said, if anything
  * @returns {Promise<string>}
@@ -492,7 +499,8 @@ export async function describeRequest(isRoundPending, recorded) {
     return (
       `requested: asked ${COPILOT_REVIEWER}, the mutation succeeded, and GitHub's own response ` +
       `does not list Copilot among the pull request's requested reviewers — the request did not ` +
-      `take (#58). Nothing this job can do will produce a round; the check will expire.`
+      `take (#58). Nothing this job can do will produce a round. It keeps waiting anyway: a round ` +
+      `requested from outside it, by a user, still lands and still counts.`
     );
   }
   if (!isRoundPending) return `requested: asked ${COPILOT_REVIEWER} for a round`;

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -367,7 +367,8 @@ describe("describeRequest (#58)", () => {
 
   it("says outright that the check will expire when GitHub did not record it", async () => {
     const line = await describeRequest(undefined, false);
-    expect(line).toMatch(/does not list Copilot among the reviewers/);
+    // Names the list it actually read — `reviewRequests`, not the reviews. (Raised by Copilot on #63.)
+    expect(line).toMatch(/does not list Copilot among the pull request's requested reviewers/);
     expect(line).toMatch(/the check will expire/);
     // No hedging here — unlike the poll, this reading has no innocent explanation.
     expect(line).not.toMatch(/took it up already/);

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -365,12 +365,20 @@ describe("describeRequest (#58)", () => {
     expect(await describeRequest(alsoContradicting, false)).toMatch(/did not take \(#58\)/);
   });
 
-  it("says outright that the check will expire when GitHub did not record it", async () => {
+  /*
+   * Definite about what GitHub said, and deliberately not about what happens next. An earlier
+   * draft ended "the check will expire", which the loop does not guarantee: it keeps polling, and
+   * #58's own documented workaround — a user requesting the round by hand — lands inside that
+   * window and turns the check green. (Raised by Copilot on #63.)
+   */
+  it("is definite about GitHub's answer and not about the run's outcome", async () => {
     const line = await describeRequest(undefined, false);
     // Names the list it actually read — `reviewRequests`, not the reviews. (Raised by Copilot on #63.)
     expect(line).toMatch(/does not list Copilot among the pull request's requested reviewers/);
-    expect(line).toMatch(/the check will expire/);
-    // No hedging here — unlike the poll, this reading has no innocent explanation.
+    expect(line).toMatch(/Nothing this job can do will produce a round/);
+    expect(line).toMatch(/still lands and still counts/);
+    expect(line).not.toMatch(/will expire/);
+    // No hedging on GitHub's answer, though — unlike the poll, that reading has no innocent one.
     expect(line).not.toMatch(/took it up already/);
   });
 

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -348,8 +348,36 @@ describe("describeRequest (#58)", () => {
         throw new Error("boom");
       }),
       await describeRequest(undefined),
+      await describeRequest(undefined, true),
+      await describeRequest(undefined, false),
     ];
     for (const line of lines) expect(line, line).toMatch(/^requested: /);
+  });
+
+  /*
+   * The mutation's own response is the post-mutation state, so it is not racing Copilot the way
+   * the poll below is. It wins wherever it exists.
+   */
+  it("prefers what the mutation reported over a later poll", async () => {
+    const contradicting = async () => false;
+    expect(await describeRequest(contradicting, true)).toMatch(/GitHub recorded it/);
+    const alsoContradicting = async () => true;
+    expect(await describeRequest(alsoContradicting, false)).toMatch(/did not take \(#58\)/);
+  });
+
+  it("says outright that the check will expire when GitHub did not record it", async () => {
+    const line = await describeRequest(undefined, false);
+    expect(line).toMatch(/does not list Copilot among the reviewers/);
+    expect(line).toMatch(/the check will expire/);
+    // No hedging here — unlike the poll, this reading has no innocent explanation.
+    expect(line).not.toMatch(/took it up already/);
+  });
+
+  it("falls back to the poll when the mutation reported nothing either way", async () => {
+    for (const recorded of [null, undefined]) {
+      expect(await describeRequest(async () => true, recorded)).toMatch(/on order/);
+      expect(await describeRequest(async () => false, recorded)).toMatch(/took it up already/);
+    }
   });
 
   it("claims nothing when there is no way to check", async () => {
@@ -865,8 +893,21 @@ describe("makeGithubIo", () => {
     const BOT = { body: { node_id: "BOT_x" } };
     const PR_ID = { body: { data: { repository: { pullRequest: { id: "PR_x" } } } } };
 
+    /** The mutation's answer, shaped as GitHub returns it. */
+    const mutationSaying = (logins: string[]) => ({
+      body: {
+        data: {
+          requestReviews: {
+            pullRequest: {
+              reviewRequests: { nodes: logins.map((login) => ({ requestedReviewer: { login } })) },
+            },
+          },
+        },
+      },
+    });
+
     it("looks the bot up, then mutates with its node id", async () => {
-      const g = io([BOT, PR_ID, { body: { data: { requestReviews: { pullRequest: { id: "PR_x" } } } } }]);
+      const g = io([BOT, PR_ID, mutationSaying([COPILOT_BOT_LOGIN])]);
       await g.requestRound();
       expect(g.calls[0].url).toContain("/users/copilot-pull-request-reviewer%5Bbot%5D");
       const mutation = JSON.parse(g.calls[2].init?.body as string);
@@ -874,6 +915,47 @@ describe("makeGithubIo", () => {
       // `union` is what stops the call evicting a human reviewer already on the pull request.
       expect(mutation.query).toContain("union:true");
       expect(mutation.variables).toEqual({ pullRequestId: "PR_x", botIds: ["BOT_x"] });
+    });
+
+    /*
+     * #58 — the selection is the diagnosis. It used to ask for `pullRequest { id }`, the one field
+     * that comes back whether or not the mutation did anything, and discarded the response. So a
+     * mutation accepted-and-dropped looked exactly like one that worked.
+     */
+    it("asks the mutation to return the reviewers it just set", async () => {
+      const g = io([BOT, PR_ID, mutationSaying([COPILOT_BOT_LOGIN])]);
+      await g.requestRound();
+      const mutation = JSON.parse(g.calls[2].init?.body as string);
+      expect(mutation.query).toContain("reviewRequests");
+      expect(mutation.query).not.toMatch(/pullRequest\{\s*id\s*\}/);
+    });
+
+    it("reports recorded when GitHub's answer lists Copilot", async () => {
+      const g = io([BOT, PR_ID, mutationSaying([COPILOT_BOT_LOGIN])]);
+      await expect(g.requestRound()).resolves.toEqual({ recorded: true });
+    });
+
+    /*
+     * The measured Dependabot case: accepted, and Copilot is not in the resulting reviewer list.
+     * A human reviewer in that list must not be mistaken for the round having been requested.
+     */
+    it("reports not-recorded when the answer comes back without Copilot", async () => {
+      const g = io([BOT, PR_ID, mutationSaying([])]);
+      await expect(g.requestRound()).resolves.toEqual({ recorded: false });
+      const h = io([BOT, PR_ID, mutationSaying(["marius-cetanas"])]);
+      await expect(h.requestRound()).resolves.toEqual({ recorded: false });
+    });
+
+    /*
+     * `null`, not `false`: an absent field is "this response did not say", which is a different
+     * claim from "GitHub says Copilot is not requested". Collapsing them would report a defect on
+     * any future schema change.
+     */
+    it("reports unknown rather than not-recorded when the shape is unfamiliar", async () => {
+      for (const answer of [{ body: { data: {} } }, { body: { data: { requestReviews: null } } }]) {
+        const g = io([BOT, PR_ID, answer]);
+        await expect(g.requestRound()).resolves.toEqual({ recorded: null });
+      }
     });
 
     /**


### PR DESCRIPTION
Refs #58, which **stays open** — this diagnoses it, it does not fix it. Plus the session handoff for 2026-09-02, which the stop-gate correctly asked for once the session ran past midnight UTC.

## The mutation was asking the wrong question

`requestRound` has selected this since it was written:

```graphql
requestReviews(input:{…}){ pullRequest{ id } }
```

`id` comes back whether or not the mutation did anything, and the response was discarded. So a mutation **accepted and dropped** — the measured Dependabot case — was indistinguishable from one that worked. That is the whole symptom of #58, and it cost #55, #56 and #57 a red required check each, under a success line at the top of every log.

It now selects `reviewRequests` back, reading the post-mutation state **in the mutation's own response**.

## Why this beats the poll added earlier in the session

`describeRequest` already re-checked `isRoundPending()` after the mutation. That check asks again *afterwards* and races Copilot, so "nothing pending" has an innocent reading — Copilot may have taken it up already, measured on #49 — and the message has to name both. The mutation's own answer is the state at the moment of the write. It has no innocent reading, so that line does not hedge:

> requested: asked … the mutation succeeded, and GitHub's own response does not list Copilot among the reviewers — the request did not take (#58). Nothing this job can do will produce a round; the check will expire.

The mutation's answer is preferred wherever it exists; the poll stays as the fallback for any caller that does not report one.

`null` rather than `false` when the response shape is unfamiliar: an absent field is *"this response did not say"*, a different claim from *"GitHub says Copilot is not requested"*, and collapsing the two would report a defect on any future schema change.

## What it does not do

Nothing here makes GitHub honour the request. A Dependabot pull request still needs the round requested by hand. What it buys is that **the next Dependabot pull request states the failure in one line**, where establishing it this session took timeline archaeology across four pull requests — at no cost, since the field is free in a request already being made.

No mechanism fix ships, and the reason is that the choice is not mine to make. The two candidates are not equivalent:

- **`pull_request_target`** gets a non-Dependabot token but keeps `github-actions[bot]` as the actor, so it helps only if the discriminator is the token context.
- **A user-scoped PAT in Dependabot secrets** works under either discriminator and **introduces a stored credential** — precisely the property the release design is built to avoid.

That is a gate-map decision. The instrumentation turns the next Dependabot bump into the experiment that tells you which one you need.

## Verification

`npm run build && npm run test:coverage && npm audit --audit-level=high`: **570 passed / 51 skipped across 29 files** (7 new assertions), 100% statements (263/263), branches (100/100), functions (64/64) and lines (262/262) on `src/`, 0 vulnerabilities. `npx portulan compile --check` GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw)_