### PR TITLE
fix(ci): ask for the review directly when the round cannot be requested (#58)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -35,8 +35,13 @@
 # GitHub's fix for it is an organization policy on Copilot Business/Enterprise, and this repository
 # is user-owned, so it is not available here. `pull_request_target` does not help: it changes the
 # token, not the actor. Only a user-scoped token would, and that is a stored credential and a
-# gate-map decision. So a Dependabot pull request needs the round requested by hand and this job
-# re-run. See #58 for the citations.
+# gate-map decision.
+#
+# So the gate stops asking for a round it cannot get. When the mutation's own answer says the
+# request was not recorded, the job waits for a **human review of the head** instead — the same
+# answer it already gives a diff Copilot will not read. A Dependabot bump used to cost four manual
+# steps (hand-request the round, wait for it to be declined, review, re-run); the first two only
+# ever produced a round known to be empty, and are gone. See #58 for the citations.
 #
 # ## A round is not a review just because it arrived (#54)
 #

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -57,7 +57,7 @@ this session took timeline archaeology across four pull requests.
   was right to: four of the session's merges carry this date and the series would have had nothing
   under it.
 
-## The mistake I made seven times
+## The mistake I made eight times
 
 Worth recording because it is the session's only repeated one, and it is not a coding mistake.
 
@@ -67,11 +67,15 @@ exemption two lines above assertions contradicting it; a heading scoping a cost 
 request; a log line predicting an expiry the loop had stopped guaranteeing; and this file saying
 that line still predicts it; this file's own "in flight, not pushed" note, still saying so after
 #63 merged it; and — in the commit fixing that one — its **Recoverability** paragraph, still
-saying the same commit was the only work not on `main`. Copilot found six of the seven. None was
-found by me re-reading the diff, because the sentences were true when written and I read them as
-ones I had already checked.
+saying the same commit was the only work not on `main`; and #64's own description, still giving a
+count the commit it described had moved on from. Copilot found seven of the eight. None was found
+by me re-reading the diff, because the sentences were true when written and I read them as ones I
+had already checked.
 
-The last two are the ones worth keeping. The sixth is in the paragraph naming the pattern, written
+The eighth is outside the tree entirely — a pull request description — which is the reminder that
+the pattern is not about code comments. Anything written *about* a change ages against it.
+
+The two before it are the ones worth keeping. The sixth is in the paragraph naming the pattern, written
 by the person naming it, in the same commit. The seventh is in the commit that fixed the sixth: I
 corrected one sentence about where `ccd4793` was and left an identical claim eleven lines below,
 because I fixed what I was shown instead of grepping for the claim — the exact habit named below,
@@ -82,8 +86,10 @@ That is why the mitigation has to be mechanical.
 
 The generalisable part: **prose is not covered by the tests that cover the code it describes**, so
 changing behaviour is exactly when its description is least trustworthy and most trusted. The
-cheap habit that would have caught all five is to grep the branch for the claim being invalidated
-rather than only the code, in the same commit that invalidates it.
+cheap habit that would have caught every one of them is to grep the branch for the claim being
+invalidated rather than only the code, in the same commit that invalidates it. Where a claim can be
+pinned by an assertion instead, it should be: the log line's wording is, and when this session
+changed it the suite failed rather than a reviewer noticing.
 
 ## Open questions *(human-owned)*
 
@@ -118,8 +124,33 @@ request with nothing to bill is dropped *silently*, with no `review_requested` e
 error. That half is still ours, measured and not confirmed by any source. The citations, their
 provenance, and the docs-vs-inference split are on #58.
 
-**Next action.** #58 needs one decision — stored user token, or keep the manual step. Nothing else
-about it is open.
+## What #58 turned out to allow after all, and its closure
+
+The decision above — stored token or manual step — was a false choice, and a second opinion found
+the third answer by reading the code rather than the issue.
+
+Since #61 the check already accepts **a human review of the head** — but only inside the
+declined-diff branch. So a Dependabot lockfile bump cost four manual steps: hand-request the round,
+wait for Copilot to decline it, review, re-run. **The first two existed only to obtain a round
+already known to be empty**, whose sole function was to reach the branch that then asked for the
+review — the real requirement all along.
+
+So the gate now takes that same path when the request provably could not be placed
+(`recorded === false`, which #63 made observable). Same ruling as #61, one more trigger; no
+credential, no exemption, and the human review unchanged. Two steps that produced no information
+are gone.
+
+It widens what satisfies the check and never narrows it: a Copilot round arriving anyway — because
+a user requested one from outside the job, the documented workaround — still wins, and the flag is
+off by default so nothing about an ordinary pull request changes.
+
+**#58 is closed on that**, with the caveat recorded rather than buried: the underlying mechanism is
+untouched and unreachable. GitHub will still not place the request, and only a stored user-scoped
+token would change that. What closed is the cost of living with it.
+
+**Next action.** Nothing outstanding. The first Dependabot batch after this is the first live
+reading of `recorded`, which no run has yet produced — #63's own check never called `requestRound`,
+the ruleset having already placed the request.
 
 **Recoverability.** Nothing partial. Every pull request this session opened is merged, squashed and
 its branch deleted; no tag was pushed and no release was run, so the published version is unchanged

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -57,7 +57,7 @@ this session took timeline archaeology across four pull requests.
   was right to: four of the session's merges carry this date and the series would have had nothing
   under it.
 
-## The mistake I made six times
+## The mistake I made seven times
 
 Worth recording because it is the session's only repeated one, and it is not a coding mistake.
 
@@ -65,14 +65,20 @@ Every time behaviour changed here, a sentence describing the old behaviour survi
 `copilot-round.mjs` claiming the ask "fixes both" holes; a test comment describing the `not-owed`
 exemption two lines above assertions contradicting it; a heading scoping a cost to every pull
 request; a log line predicting an expiry the loop had stopped guaranteeing; and this file saying
-that line still predicts it; and this file's own "in flight, not pushed" note, still saying so
-after #63 merged it. Copilot found five of the six. None was found by me re-reading the diff,
-because the sentences were true when written and I read them as ones I had already checked.
+that line still predicts it; this file's own "in flight, not pushed" note, still saying so after
+#63 merged it; and — in the commit fixing that one — its **Recoverability** paragraph, still
+saying the same commit was the only work not on `main`. Copilot found six of the seven. None was
+found by me re-reading the diff, because the sentences were true when written and I read them as
+ones I had already checked.
 
-The sixth is the one worth keeping: it is in the paragraph naming the pattern, written by the
-person naming it, in the same commit. Knowing the failure mode and having just described it was
-not enough to avoid it once more — which is the argument for the grep habit below being a habit
-rather than a resolution.
+The last two are the ones worth keeping. The sixth is in the paragraph naming the pattern, written
+by the person naming it, in the same commit. The seventh is in the commit that fixed the sixth: I
+corrected one sentence about where `ccd4793` was and left an identical claim eleven lines below,
+because I fixed what I was shown instead of grepping for the claim — the exact habit named below,
+skipped while writing it down.
+
+Knowing the failure mode, having just described it, and being mid-correction were each not enough.
+That is why the mitigation has to be mechanical.
 
 The generalisable part: **prose is not covered by the tests that cover the code it describes**, so
 changing behaviour is exactly when its description is least trustworthy and most trusted. The
@@ -115,7 +121,6 @@ provenance, and the docs-vs-inference split are on #58.
 **Next action.** #58 needs one decision — stored user token, or keep the manual step. Nothing else
 about it is open.
 
-**Recoverability.** Nothing partial on the remote: every merged pull request is squashed and its
-branch deleted, no tag was pushed, no release was run. The only work not on `main` is `ccd4793` on
-this branch, which is one commit, verified green, and carries no behaviour change beyond a log line
-and a GraphQL selection.
+**Recoverability.** Nothing partial. Every pull request this session opened is merged, squashed and
+its branch deleted; no tag was pushed and no release was run, so the published version is unchanged
+at 1.3.3. `main` carries every change described above.

--- a/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
+++ b/.portulan/handoffs/2026-09-02-the-selection-was-the-diagnosis.md
@@ -12,8 +12,11 @@ version unchanged at **1.3.3**; the next derived release is **1.3.4**, a patch f
 subject for a change that ships nothing, `src/` being untouched — the wart `CLAUDE.md` names, with
 `bump` as the override. **Open: #58 only.**
 
-**In flight, committed and not pushed:** `ccd4793`, the #58 diagnosis below. A research agent was
-still running when this was written; its findings are not in here.
+Everything described below landed in **#63**, including the research findings — which were still
+being gathered when this file was first written, and which are now the section on the mechanism.
+_(The "in flight, not pushed" note this replaces is the sixth instance of the pattern recorded
+below, in the file recording it. Left as a correction rather than a silent edit, because the count
+is the evidence.)_
 
 ## What #58 turned out to need first
 
@@ -54,7 +57,7 @@ this session took timeline archaeology across four pull requests.
   was right to: four of the session's merges carry this date and the series would have had nothing
   under it.
 
-## The mistake I made five times
+## The mistake I made six times
 
 Worth recording because it is the session's only repeated one, and it is not a coding mistake.
 
@@ -62,8 +65,14 @@ Every time behaviour changed here, a sentence describing the old behaviour survi
 `copilot-round.mjs` claiming the ask "fixes both" holes; a test comment describing the `not-owed`
 exemption two lines above assertions contradicting it; a heading scoping a cost to every pull
 request; a log line predicting an expiry the loop had stopped guaranteeing; and this file saying
-that line still predicts it. Copilot found all five. None was found by me re-reading the diff,
+that line still predicts it; and this file's own "in flight, not pushed" note, still saying so
+after #63 merged it. Copilot found five of the six. None was found by me re-reading the diff,
 because the sentences were true when written and I read them as ones I had already checked.
+
+The sixth is the one worth keeping: it is in the paragraph naming the pattern, written by the
+person naming it, in the same commit. Knowing the failure mode and having just described it was
+not enough to avoid it once more — which is the argument for the grep habit below being a habit
+rather than a resolution.
 
 The generalisable part: **prose is not covered by the tests that cover the code it describes**, so
 changing behaviour is exactly when its description is least trustworthy and most trusted. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- `copilot-reviewed` no longer counts a Copilot round that contains no review as a review. Copilot
+  submits one in two cases where nobody looked, and the check accepted both — so the merge gate was
+  satisfied by the absence of a review, which is what it exists to prevent. Measured twice: an error
+  round nearly merged #53, and two lockfile-only pull requests did merge on *"Copilot wasn't able to
+  review any files in this pull request"* (#54).
+
+  The two get different answers, because only one can be fixed by asking again. An error round is
+  transient, so the check keeps waiting and asks for another. A diff Copilot will not read — a
+  lockfile, which it excludes by documented policy — is permanent, so the review that is owed is a
+  person's: the check waits for a human review of the same head. Any human review counts rather than
+  only an approval, because GitHub forbids approving your own pull request and an approval-only rule
+  would leave a maintainer-authored lockfile change unmergeable by anyone here.
+
+- The check no longer reports a review request that GitHub silently discarded as a success. On a
+  Dependabot pull request the `requestReviews` mutation resolves, records nothing, and the check
+  used to expire red ten minutes later under a success line at the top of the log. The mutation now
+  returns the pull request's requested reviewers, so GitHub's own answer says whether the request
+  took (#58).
+
+  The cause is documented and structural rather than a defect here: a Copilot review must be billed
+  to a Copilot-licensed account, and where the author is a bot and the requester an app there is
+  none. GitHub's remedy is an organization policy unavailable to a user-owned repository, and no
+  workflow rearrangement reaches it — `pull_request_target` changes the token, not the actor.
+
+  So the gate stops asking for a round it cannot get and asks for the review instead: when the
+  request provably did not take, a human review of the head satisfies the check. A Dependabot bump
+  used to cost four manual steps — hand-request the round, wait for it to be declined, review,
+  re-run — of which the first two only ever produced a round already known to be empty.
+
 ## [1.3.3] - 2026-08-26
 
 ### Fixed

--- a/scripts/copilot-round.mjs
+++ b/scripts/copilot-round.mjs
@@ -165,10 +165,14 @@ export function emptyRound(body) {
 }
 
 /**
- * @param {{reviews: Array<object>, head: string, draft?: boolean}} input
+ * @param {{reviews: Array<object>, head: string, draft?: boolean,
+ *          roundUnobtainable?: boolean}} input
+ *   `roundUnobtainable` is set by the loop once GitHub's own answer to the request said the round
+ *   was not recorded (#58). It never suppresses a Copilot round — one that arrives anyway, because
+ *   somebody requested it from outside the job, still wins — it only adds the human-review path.
  * @returns {{state: "landed"|"awaited"|"not-owed", reason: string, awaiting?: "human"}}
  */
-export function classifyRound({ reviews, head, draft = false }) {
+export function classifyRound({ reviews, head, draft = false, roundUnobtainable = false }) {
   if (draft) {
     return {
       state: "not-owed",
@@ -205,32 +209,49 @@ export function classifyRound({ reviews, head, draft = false }) {
     };
   }
 
-  if (declined.length > 0) {
-    /*
-     * Copilot will not read this diff, so no re-request produces a round and the only reviewer
-     * left is a person. The gate holds rather than exempting the pull request: a lockfile is where
-     * a supply-chain change arrives, which is the diff least worth waving through.
-     *
-     * **Any human review on the head counts, not only an approval**, and that is a deadlock guard
-     * rather than laxity. GitHub forbids approving your own pull request, so an APPROVED-only rule
-     * would make a maintainer-authored lockfile change unmergeable by anyone — the sole maintainer
-     * cannot approve it and there is nobody else. A `COMMENTED` review is allowed on your own pull
-     * request, so the rule stays satisfiable in every case while still costing a person a look and
-     * a statement on the record against this exact tree.
-     */
+  /*
+   * Two ways no Copilot round is coming, and one answer to both: the review that is owed is a
+   * person's.
+   *
+   *   * **Copilot declined the diff** (#54) — it will not read a lockfile, and re-requesting does
+   *     not change the diff.
+   *   * **The request could not be placed at all** (#58) — GitHub's own response to the mutation
+   *     did not list Copilot, which on a Dependabot pull request here it never will: a review must
+   *     be billed to a Copilot-licensed account and this combination has none.
+   *
+   * The gate holds rather than exempting either: a lockfile is where a supply-chain change
+   * arrives, which is the diff least worth waving through.
+   *
+   * **Any human review on the head counts, not only an approval**, and that is a deadlock guard
+   * rather than laxity. GitHub forbids approving your own pull request, so an APPROVED-only rule
+   * would make a maintainer-authored lockfile change unmergeable by anyone — the sole maintainer
+   * cannot approve it and there is nobody else. A `COMMENTED` review is allowed on your own pull
+   * request, so the rule stays satisfiable in every case while still costing a person a look and
+   * a statement on the record against this exact tree.
+   *
+   * **What the second case removes is ceremony, not scrutiny.** Before it, a Dependabot lockfile
+   * bump took four manual steps: request the round by hand, wait for Copilot to decline it, review,
+   * re-run. The first two existed only to obtain a round already known to be empty, whose sole
+   * function was to reach this branch — which then asked for the review that was the real
+   * requirement all along. The human review is unchanged; the two steps that produced no
+   * information are gone.
+   */
+  if (declined.length > 0 || roundUnobtainable) {
+    const why =
+      declined.length > 0
+        ? `Copilot declined to read the diff on ${short}`
+        : `no Copilot round can be requested for ${short} (#58)`;
     const humans = allOnHead.filter((r) => isHumanReviewer(r?.user));
     if (humans.length > 0) {
-      return {
-        state: "landed",
-        reason: `Copilot declined to read the diff on ${short}; ${humans.length} human review(s) on it`,
-      };
+      return { state: "landed", reason: `${why}; ${humans.length} human review(s) on it` };
     }
     return {
       state: "awaited",
-      // `human`, so the loop asks Copilot for nothing here — another round would arrive declining
-      // the same diff, and the log would name the wrong thing as missing.
+      // `human`, so the loop asks Copilot for nothing here — a further request would either
+      // decline the same diff or fail the same way, and the log would name the wrong thing as
+      // missing.
       awaiting: "human",
-      reason: `Copilot declined to read the diff on ${short} — waiting for a human review of it`,
+      reason: `${why} — waiting for a human review of it`,
     };
   }
 
@@ -362,16 +383,22 @@ export const DEFAULT_POLL_MS = 30 * 1000;
  * changes the token and the secret source but **not the actor**, which stays `github-actions[bot]`
  * — still not a user, still nothing to bill. Only a user-scoped token would work, and that means a
  * stored credential, which is a gate-map decision rather than an implementation one. So a
- * Dependabot pull request needs the round requested by hand and the job re-run; #58 carries the
- * citations, and the caveat that GitHub documents the attribution rule without documenting that
- * the request is then dropped with no `review_requested` event.
+ * Dependabot pull request cannot draw a round from this job at all; #58 carries the citations, and
+ * the caveat that GitHub documents the attribution rule without documenting that the request is
+ * then dropped with no `review_requested` event.
+ *
+ * **So the gate stops asking for a round it cannot get, and asks for the review instead.** When
+ * the mutation's own answer says the request was not recorded, `classifyRound` takes the same path
+ * as a declined diff and waits for a human review of the head. That needs no credential, and it is
+ * why the four manual steps a Dependabot bump used to cost are now one.
  *
  * The **diagnosis** is fixed — see `requestRound`, which asks the mutation to return the pull
  * request's requested reviewers, and `describeRequest`, which reports what that answer said and
  * falls back to polling `isRoundPending()` only when the mutation reported nothing either way.
  * Neither calls an unconfirmed request a success. The **mechanism** is not fixed and cannot be
- * fixed here: no workflow rearrangement supplies an account to bill, so #58 stays open and the
- * manual step stands.
+ * fixed here: no workflow rearrangement supplies an account to bill. What is fixed is the cost of
+ * living with it — the gate now asks for the human review directly rather than for a round that
+ * cannot arrive.
  *
  * I/O is injected so the loop is testable without a network or a clock.
  *
@@ -384,6 +411,13 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
   let waited = 0;
   let polls = 0;
   let asked = false;
+  /*
+   * Set once GitHub's own answer to the request says the round was not recorded (#58), and never
+   * cleared: the reason it failed does not go away inside one run. It only widens what satisfies
+   * the check — a Copilot round arriving anyway still wins, which matters because a user can
+   * request one from outside this job while it waits.
+   */
+  let roundUnobtainable = false;
 
   for (;;) {
     polls += 1;
@@ -393,6 +427,7 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
       reviews,
       head: pr?.head?.sha,
       draft: Boolean(pr?.draft),
+      roundUnobtainable,
     });
 
     if (result.state !== "awaited") {
@@ -432,11 +467,29 @@ export async function awaitRound({ api, sleep, requestRound, isRoundPending, bud
         // right answer is the one the check always had: wait, and let the budget decide.
         try {
           const outcome = await requestRound();
+          if (outcome?.recorded === false) roundUnobtainable = true;
           log(await describeRequest(isRoundPending, outcome?.recorded));
         } catch (err) {
           log(`could not request a round (${describeError(err)}) — waiting anyway`);
         }
       }
+    }
+
+    /*
+     * Re-decide inside the same poll when the ask just told us no round is coming (#58). Waiting
+     * for the next one would sit out a full poll interval before noticing a human review that is
+     * already on the head — and on a run whose budget is nearly spent, could miss it entirely.
+     */
+    if (roundUnobtainable) {
+      const again = classifyRound({
+        reviews,
+        head: pr?.head?.sha,
+        draft: Boolean(pr?.draft),
+        roundUnobtainable,
+      });
+      if (again.state !== "awaited") return { ...again, polls };
+      result.reason = again.reason;
+      result.awaiting = again.awaiting;
     }
 
     if (waited >= budgetMs) {
@@ -501,8 +554,8 @@ export async function describeRequest(isRoundPending, recorded) {
     return (
       `requested: asked ${COPILOT_REVIEWER}, the mutation succeeded, and GitHub's own response ` +
       `does not list Copilot among the pull request's requested reviewers — the request did not ` +
-      `take (#58). Nothing this job can do will produce a round. It keeps waiting anyway: a round ` +
-      `requested from outside it, by a user, still lands and still counts.`
+      `take (#58). No round is coming from this job, so a human review of this head now satisfies ` +
+      `the check instead. A round requested from outside it, by a user, still lands and still counts.`
     );
   }
   if (!isRoundPending) return `requested: asked ${COPILOT_REVIEWER} for a round`;

--- a/tests/workflows/copilot-round.test.ts
+++ b/tests/workflows/copilot-round.test.ts
@@ -275,6 +275,59 @@ describe("classifyRound on rounds that reviewed nothing (#54)", () => {
   });
 });
 
+describe("classifyRound when no round can be requested at all (#58)", () => {
+  const human = { user: { login: "marius-cetanas", type: "User" }, commit_id: HEAD, body: "lgtm" };
+
+  /*
+   * The generalisation of #61's ruling, not a return of the `not-owed` exemption it replaced. Two
+   * ways no round is coming — Copilot will not read the diff, or the request cannot be placed —
+   * and one answer to both: a person's review of this head.
+   */
+  it("waits for a human when the request could not be placed", () => {
+    const r = classifyRound({ reviews: [], head: HEAD, roundUnobtainable: true });
+    expect(r.state).toBe("awaited");
+    expect(r.awaiting).toBe("human");
+    expect(r.reason).toMatch(/no Copilot round can be requested/);
+  });
+
+  it("is satisfied by a human review of the same head", () => {
+    const r = classifyRound({ reviews: [human], head: HEAD, roundUnobtainable: true });
+    expect(r.state).toBe("landed");
+    expect(r.reason).toMatch(/1 human review\(s\)/);
+  });
+
+  /*
+   * The flag widens what satisfies the check; it must never narrow it. A round that arrives anyway
+   * — because a user requested one from outside the job, which is the documented workaround —
+   * still wins, and still wins over a human review.
+   */
+  it("never suppresses a Copilot round that arrives anyway", () => {
+    const r = classifyRound({
+      reviews: [round("Copilot", HEAD, REAL_BODY)],
+      head: HEAD,
+      roundUnobtainable: true,
+    });
+    expect(r.state).toBe("landed");
+    expect(r.reason).toMatch(/the commit being merged/);
+  });
+
+  it("does not accept a bot review, or a human review of an earlier commit", () => {
+    for (const review of [
+      { user: { login: "dependabot[bot]", type: "Bot" }, commit_id: HEAD, body: "x" },
+      { ...human, commit_id: OLDER },
+    ]) {
+      expect(classifyRound({ reviews: [review], head: HEAD, roundUnobtainable: true }).state).toBe(
+        "awaited"
+      );
+    }
+  });
+
+  /** Off by default, so nothing about an ordinary pull request changes. */
+  it("changes nothing when the flag is not set", () => {
+    expect(classifyRound({ reviews: [human], head: HEAD }).state).toBe("awaited");
+  });
+});
+
 describe("isHumanReviewer", () => {
   it("accepts a person", () => {
     expect(isHumanReviewer({ login: "marius-cetanas", type: "User" })).toBe(true);
@@ -375,7 +428,8 @@ describe("describeRequest (#58)", () => {
     const line = await describeRequest(undefined, false);
     // Names the list it actually read — `reviewRequests`, not the reviews. (Raised by Copilot on #63.)
     expect(line).toMatch(/does not list Copilot among the pull request's requested reviewers/);
-    expect(line).toMatch(/Nothing this job can do will produce a round/);
+    expect(line).toMatch(/No round is coming from this job/);
+    expect(line).toMatch(/a human review of this head now satisfies the check/);
     expect(line).toMatch(/still lands and still counts/);
     expect(line).not.toMatch(/will expire/);
     // No hedging on GitHub's answer, though — unlike the poll, that reading has no innocent one.
@@ -588,6 +642,42 @@ describe("awaitRound requesting the round (#44)", () => {
     expect(result.state).toBe("expired");
     expect(result.reason).toMatch(/waiting for a human review/);
     expect(s.asked).toBe(0);
+  });
+
+  /*
+   * The ceremony this removes: before it, a Dependabot lockfile bump took four manual steps —
+   * request the round by hand, wait for Copilot to decline it, review, re-run. The first two
+   * existed only to obtain a round already known to be empty, whose sole function was to reach the
+   * branch that then asked for the review. The review is unchanged; the two empty steps are gone.
+   */
+  it("accepts a human review once the ask reports the request did not take (#58)", async () => {
+    const s2 = spy();
+    const result = await awaitRound({
+      api: apiWith([{ user: { login: "marius-cetanas", type: "User" }, commit_id: HEAD, body: "ok" }]),
+      requestRound: async () => ({ recorded: false }),
+      isRoundPending: notPending,
+      sleep: noSleep,
+      budgetMs: 0,
+      log: s2.log,
+    });
+    expect(result.state).toBe("landed");
+    // Same poll, not the next one: waiting would sit out a full interval before noticing a review
+    // already on the head, and on a nearly-spent budget could miss it entirely.
+    expect(result.polls).toBe(1);
+  });
+
+  it("still expires when the request did not take and nobody has reviewed", async () => {
+    const s2 = spy();
+    const result = await awaitRound({
+      api: apiWith([]),
+      requestRound: async () => ({ recorded: false }),
+      isRoundPending: notPending,
+      sleep: noSleep,
+      budgetMs: 0,
+      log: s2.log,
+    });
+    expect(result.state).toBe("expired");
+    expect(result.reason).toMatch(/waiting for a human review/);
   });
 
   it("goes green the moment the human review of that head exists", async () => {


### PR DESCRIPTION
Closes #58. Retitled from a docs-only change once the branch grew a behaviour change; the handoff corrections it started as are still here, at the bottom.

## The manual step was mostly ceremony

Since #61, `copilot-reviewed` already accepts **a human review of the head** — but only inside the declined-diff branch (`humans` is consulted under `if (declined.length > 0)`). So a Dependabot lockfile bump cost four manual steps:

1. hand-request the Copilot round
2. wait for Copilot to decline it
3. leave a review
4. re-run the expired job

**Steps 1 and 2 existed only to obtain a round already known to be empty**, whose sole function was to route the classifier into the branch that then asked for step 3 — the real requirement all along.

`classifyRound` now takes that same path when the request provably could not be placed: `recorded === false`, which #63 made observable. Same ruling as #61 with one more trigger. No credential, no exemption, the human review unchanged, and the two uninformative steps gone.

## What it does not do

- **It never narrows the gate.** A Copilot round that arrives anyway — because a user requested one from outside the job, which is #58's documented workaround — still wins, and still wins over a human review. Asserted.
- **It is off by default**, so an ordinary pull request behaves exactly as before. Asserted.
- **It does not fix #58's mechanism**, which is unreachable: GitHub will not place the request because a Copilot review must be billed to a licensed account and this combination has none; its remedy is an org policy a user-owned repository cannot enable. Only a stored user-scoped token would change that, and this repo is built around not having one. **What closes is the cost of living with it, not the cause** — recorded that way in the issue, the workflow header and the handoff rather than left to be rediscovered.

One judgement worth flagging: on a *human-authored* pull request where the request somehow fails, this also lets a human review satisfy the check — and since any review counts (the self-approval deadlock guard from #61), that could be the author's own comment review. The documented mechanism says that case should not arise, since a licensed author is attributable. It is a real widening in an anomaly, and it is preferable to a pull request nothing can make mergeable.

## Also here

- **The `[Unreleased]` changelog entry** for #54, #58 and #61, which was empty across two changes to a required check. That is the window that cost 1.3.1 its entry — the workflow cannot commit to `main` after tagging, so a version's entry can only be written before its tag exists.
- **The handoff corrections this branch started as**, plus the count moving to eight: #64's own description was the eighth instance of the pattern the handoff records, having been made stale by the commit it described. Copilot found seven of the eight.

## Verification

`npm run build && npm run test:coverage && npm audit --audit-level=high`: **577 passed / 51 skipped across 29 files**, 100% statements (263/263), branches (100/100), functions (64/64) and lines (262/262) on `src/`, 0 vulnerabilities. `npx portulan compile --check` GREEN.

Every claim this change invalidated was found by grepping the branch for the claim rather than re-reading the diff — the habit the handoff prescribes, applied this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw