### PR TITLE
docs(changelog): record 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-09-02
+
 ### Internal
 
 - `copilot-reviewed` no longer counts a Copilot round that contains no review as a review. Copilot


### PR DESCRIPTION
Changelog only. **This must land before the release runs** — it is the prerequisite, not a follow-up.

## Why it goes first

The release workflow never commits to `main`, so a version's entry can only be written **before its tag exists**. Miss the window and the entry needs its own pull request afterwards, which is exactly how 1.3.1 shipped with no entry and had to be backfilled from its own commits.

## What it does

Inserts `## [1.3.4] - 2026-09-02` **below** the standing `## [Unreleased]` heading, rather than renaming it. Renaming is the natural move and it silently removes the standing heading, leaving the next change nowhere to land — both halves are asserted in `tests/release/changelog.test.ts`, which passes.

The entry itself is unchanged from what landed in #64; this only files it under a version.

## Release pre-flight, run on this tree

| check | result |
|---|---|
| `npm run build && npm run test:coverage` | **577 passed / 51 skipped**, 100% statements (263/263), branches (100/100), functions (64/64), lines (262/262) |
| `npm audit --audit-level=high` | 0 vulnerabilities |
| `tests/release/changelog.test.ts` | 7 passed — standing heading present, at top, undated; every other heading dated |
| `scripts/check-npmrc.mjs` | exit 0 — nothing would disable OIDC |
| `scripts/next-version.mjs --current 1.3.3 --since v1.3.3` | `1.3.4`, `patch`, `releasable: true`, 13 commits considered |

Worth stating plainly on the release itself: **1.3.4 ships no consumer-facing change.** `src/` is untouched since 1.3.3 — every commit in the range is CI machinery, governance or documentation. The patch bump comes from the `fix(ci):` subjects, which is the wart `CLAUDE.md` names, and `bump` is the override if you would rather not cut it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3yncfaGtPZwrEZbaFdxEw)_